### PR TITLE
Added unavailable notices for DateComponentsFormatter and RelativeDateTimeFormatter…

### DIFF
--- a/Sources/SkipFoundation/DateComponentsFormatter.swift
+++ b/Sources/SkipFoundation/DateComponentsFormatter.swift
@@ -1,0 +1,13 @@
+// Copyright 2023 Skip
+//
+// This is free software: you can redistribute and/or modify it
+// under the terms of the GNU Lesser General Public License 3.0
+// as published by the Free Software Foundation https://fsf.org
+
+#if SKIP
+
+@available(*, unavailable)
+public struct DateComponentsFormatter {
+}
+
+#endif

--- a/Sources/SkipFoundation/RelativeDateTimeFormatter.swift
+++ b/Sources/SkipFoundation/RelativeDateTimeFormatter.swift
@@ -1,0 +1,13 @@
+// Copyright 2023 Skip
+//
+// This is free software: you can redistribute and/or modify it
+// under the terms of the GNU Lesser General Public License 3.0
+// as published by the Free Software Foundation https://fsf.org
+
+#if SKIP
+
+@available(*, unavailable)
+public struct RelativeDateTimeFormatter {
+}
+
+#endif


### PR DESCRIPTION
I added an unavailable notice for DateComponentsFormatter, as there was none already set. This gives a more meaningful error in Xcode when its use is attempted.