### PR TITLE
Calendar.dateComponents was not zeroing unset components fields

### DIFF
--- a/Sources/SkipFoundation/Calendar.swift
+++ b/Sources/SkipFoundation/Calendar.swift
@@ -228,7 +228,7 @@ public struct Calendar : Hashable, Codable, CustomStringConvertible {
 
     public func date(from components: DateComponents) -> Date? {
         // TODO: Need to set `this` calendar in the components.calendar
-        return Date(platformValue: components.createCalendarComponents().getTime())
+        return Date(platformValue: components.createCalendarComponents(timeZone: self.timeZone).getTime())
     }
 
     public func dateComponents(in zone: TimeZone? = nil, from date: Date) -> DateComponents {


### PR DESCRIPTION
This bug could lead to the following code returning inconsistent dates between Foundation and SkipFoundation:

```swift
let date = Date(timeIntervalSince1970: 1728038797.580)
let calendar = Calendar.current
calendar.timeZone = TimeZone(identifier: "Europe/Zurich")!

let components = calendar.dateComponents([.year, .month, .day], from: date)
let date2 = calendar.date(from: components)!
```

The problem is that on Foundation, the DateComponents zeros out all the un-set fields for the Date is that is returned, whereas we were not.