### PR TITLE
Add RelativeDateTimeFormatter

### DIFF
--- a/Sources/SkipFoundation/DateFormatter.swift
+++ b/Sources/SkipFoundation/DateFormatter.swift
@@ -93,6 +93,9 @@ public class DateFormatter: Formatter {
         }
     }
 
+    @available(*, unavailable)
+    override public var formattingContext: Formatter.Context = .unknown
+
     internal init(platformValue: java.text.DateFormat) {
         _platformValue = platformValue
         isLenient = platformValue.isLenient

--- a/Sources/SkipFoundation/Formatter.swift
+++ b/Sources/SkipFoundation/Formatter.swift
@@ -36,13 +36,41 @@ public class Formatter {
         return false
     }
 
-    @available(*, unavailable)
-    public var formattingContext: Any {
-        fatalError()
-    }
+    public var formattingContext: Formatter.Context = .unknown
 
     @available(*, unavailable)
     public func getObjectValue(_ obj: Any?, for string: String, range rangep: Any?, unusedp: Nothing? = nil) throws {
+    }
+}
+
+extension Formatter {
+    public enum Context: Int {
+        case unknown = 0
+        @available(*, unavailable)
+        case dynamic = 1
+        case standalone = 2
+        case listItem = 3
+        case beginningOfSentence = 4
+        case middleOfSentence = 5
+
+        internal var capitalization: android.icu.text.DisplayContext {
+            switch self {
+            case .beginningOfSentence:
+                android.icu.text.DisplayContext.CAPITALIZATION_FOR_BEGINNING_OF_SENTENCE
+//            case .dynamic:
+//                android.icu.text.DisplayContext.CAPITALIZATION_NONE
+            case .listItem:
+                android.icu.text.DisplayContext.CAPITALIZATION_FOR_UI_LIST_OR_MENU
+            case .middleOfSentence:
+                android.icu.text.DisplayContext.CAPITALIZATION_FOR_MIDDLE_OF_SENTENCE
+            case .standalone:
+                android.icu.text.DisplayContext.CAPITALIZATION_FOR_STANDALONE
+            case .unknown:
+                android.icu.text.DisplayContext.CAPITALIZATION_NONE
+            default:
+                android.icu.text.DisplayContext.CAPITALIZATION_NONE
+            }
+        }
     }
 }
 

--- a/Sources/SkipFoundation/NumberFormatter.swift
+++ b/Sources/SkipFoundation/NumberFormatter.swift
@@ -18,6 +18,9 @@ public class NumberFormatter: Formatter {
         self.groupingSize = 0
     }
 
+    @available(*, unavailable)
+    override public var formattingContext: Formatter.Context = .unknown
+
     private var _numberStyle: NumberFormatter.Style = .none
 
     public var description: String {

--- a/Sources/SkipFoundation/RelativeDateTimeFormatter.swift
+++ b/Sources/SkipFoundation/RelativeDateTimeFormatter.swift
@@ -48,13 +48,19 @@ public class RelativeDateTimeFormatter: Formatter {
         }
     }
 
+    override public var formattingContext: Formatter.Context {
+        didSet {
+            updatePlatformValue()
+        }
+    }
+
     public init () {
         locale = .current
     }
 
     private func updatePlatformValue() {
         let ulocale = locale != nil ? android.icu.util.ULocale.forLocale(locale!.platformValue) : android.icu.util.ULocale.getDefault()
-        platformValue = android.icu.text.RelativeDateTimeFormatter.getInstance(ulocale, nil, relativeDateTimeFormatterStyle, android.icu.text.DisplayContext.CAPITALIZATION_FOR_MIDDLE_OF_SENTENCE)
+        platformValue = android.icu.text.RelativeDateTimeFormatter.getInstance(ulocale, nil, relativeDateTimeFormatterStyle, formattingContext.capitalization)
     }
 
     public func localizedString(from dateComponents: DateComponents) -> String {

--- a/Sources/SkipFoundation/RelativeDateTimeFormatter.swift
+++ b/Sources/SkipFoundation/RelativeDateTimeFormatter.swift
@@ -6,8 +6,195 @@
 
 #if SKIP
 
-@available(*, unavailable)
-public struct RelativeDateTimeFormatter {
+import CoreFoundation
+
+import android.icu.text.RelativeDateTimeFormatter.AbsoluteUnit
+import android.icu.text.RelativeDateTimeFormatter.Direction
+import android.icu.text.RelativeDateTimeFormatter.RelativeUnit
+
+extension RelativeDateTimeFormatter {
+    public enum DateTimeStyle: Int {
+        case numeric = 0
+        case named = 1
+    }
+
+    public enum UnitsStyle: Int {
+        case full = 0
+        @available(*, unavailable)
+        case spellOut = 1
+        case short = 2
+        @available(*, unavailable)
+        case abbreviated = 3
+    }
+}
+
+public class RelativeDateTimeFormatter: Formatter {
+    internal var platformValue: android.icu.text.RelativeDateTimeFormatter!
+
+    public var dateTimeStyle: RelativeDateTimeFormatter.DateTimeStyle = .numeric
+
+    public var unitsStyle: RelativeDateTimeFormatter.UnitsStyle = .full {
+        didSet {
+            updatePlatformValue()
+        }
+    }
+
+    @available(*, unavailable)
+    public var calendar: Calendar!
+
+    public var locale: Locale! {
+        didSet {
+            updatePlatformValue()
+        }
+    }
+
+    public init () {
+        locale = .current
+    }
+
+    private func updatePlatformValue() {
+        let ulocale = locale != nil ? android.icu.util.ULocale.forLocale(locale!.platformValue) : android.icu.util.ULocale.getDefault()
+        platformValue = android.icu.text.RelativeDateTimeFormatter.getInstance(ulocale, nil, relativeDateTimeFormatterStyle, android.icu.text.DisplayContext.CAPITALIZATION_FOR_MIDDLE_OF_SENTENCE)
+    }
+
+    public func localizedString(from dateComponents: DateComponents) -> String {
+        var relativeUnit: RelativeUnit?
+        var absoluteUnit: AbsoluteUnit?
+        // Find the set date component, prioritizing non-zero
+        var value = 0
+        if let year = dateComponents.year {
+            value = year
+            if abs(value) == 1 && dateTimeStyle == .named {
+                absoluteUnit = AbsoluteUnit.YEAR
+            } else {
+                relativeUnit = RelativeUnit.YEARS
+            }
+        }
+        if value == 0, let month = dateComponents.month {
+            value = month
+            if abs(value) == 1 && dateTimeStyle == .named {
+                absoluteUnit = AbsoluteUnit.MONTH
+            } else {
+                relativeUnit = RelativeUnit.MONTHS
+            }
+        }
+        if value == 0, let week = dateComponents.weekOfMonth {
+            value = week
+            if abs(value) == 1 && dateTimeStyle == .named {
+                absoluteUnit = AbsoluteUnit.WEEK
+            } else {
+                relativeUnit = RelativeUnit.WEEKS
+            }
+        }
+        if value == 0, let day = dateComponents.day {
+            value = day
+            if (value == 0 || abs(value) == 1) && dateTimeStyle == .named {
+                absoluteUnit = AbsoluteUnit.DAY
+            } else {
+                relativeUnit = RelativeUnit.DAYS
+            }
+        }
+        if value == 0, let hour = dateComponents.hour {
+            value = hour
+            relativeUnit = RelativeUnit.HOURS
+        }
+        if value == 0, let minute = dateComponents.minute {
+            value = minute
+            relativeUnit = RelativeUnit.MINUTES
+        }
+        if value == 0, let second = dateComponents.second {
+            value = second
+            if value == 0 && dateTimeStyle == .named {
+                return platformValue.format(Direction.PLAIN, AbsoluteUnit.NOW)
+            }
+            relativeUnit = RelativeUnit.SECONDS
+        }
+        let direction = value == -0 || value <= 0 ? Direction.LAST : Direction.NEXT
+        if let absoluteUnit {
+            return platformValue.format(value == 0 ? Direction.THIS : direction, absoluteUnit)
+        }
+        if value == 0 && relativeUnit == nil {
+            return ""
+        }
+        let timeValue = Double(abs(value))
+        return platformValue.format(timeValue, direction, relativeUnit!)
+    }
+
+    public func localizedString(fromTimeInterval timeInterval: TimeInterval) -> String {
+        let isNegative = timeInterval < 0.0
+        let direction = isNegative ? Direction.LAST : Direction.NEXT
+        var relativeUnit: RelativeUnit?
+        var absoluteUnit: AbsoluteUnit?
+        var timeValue = abs(timeInterval)
+        if timeValue < 60.0 {
+            relativeUnit = RelativeUnit.SECONDS
+            if timeValue < 1.0 && dateTimeStyle == .named {
+                return platformValue.format(Direction.PLAIN, AbsoluteUnit.NOW)
+            }
+        } else if timeValue < 60.0 * 60.0 {
+            timeValue /= 60.0
+            relativeUnit = RelativeUnit.MINUTES
+        } else if timeValue < 60.0 * 60.0 * 24.0 {
+            timeValue /= 60.0 * 60.0
+            relativeUnit = RelativeUnit.HOURS
+        } else if timeValue < 60.0 * 60.0 * 24.0 * 7.0 {
+            timeValue /= 60.0 * 60.0 * 24.0
+            if timeValue < 2.0 && dateTimeStyle == .named {
+                absoluteUnit = AbsoluteUnit.DAY
+            } else {
+                relativeUnit = RelativeUnit.DAYS
+            }
+        } else if timeValue < 60.0 * 60.0 * 24.0 * 31.0 {
+            timeValue /= 60.0 * 60.0 * 24.0 * 7
+            if timeValue < 2.0 && dateTimeStyle == .named {
+                absoluteUnit = AbsoluteUnit.WEEK
+            } else {
+                relativeUnit = RelativeUnit.WEEKS
+            }
+        } else if timeValue < 60.0 * 60.0 * 24.0 * (isNegative ? 366.0 : 365.0) {
+            timeValue /= 60.0 * 60.0 * 24.0 * 30.4375
+            if timeValue < 2.0 && dateTimeStyle == .named {
+                absoluteUnit = AbsoluteUnit.MONTH
+            } else {
+                relativeUnit = RelativeUnit.MONTHS
+            }
+        } else {
+            timeValue /= 60.0 * 60.0 * 24.0 * 365.25
+            if timeValue < 2.0 && dateTimeStyle == .named {
+                absoluteUnit = AbsoluteUnit.YEAR
+            } else {
+                relativeUnit = RelativeUnit.YEARS
+            }
+        }
+        if let absoluteUnit {
+            return platformValue.format(direction, absoluteUnit)
+        }
+        timeValue = relativeUnit! != RelativeUnit.SECONDS && timeValue < 1.0 ? 1.0 : timeValue.rounded(.down)
+        return platformValue.format(timeValue, direction, relativeUnit!)
+    }
+
+    public func localizedString(for date: Date, relativeTo referenceDate: Date) -> String {
+        let timeInterval = date.timeIntervalSince(referenceDate)
+        return localizedString(fromTimeInterval: timeInterval)
+    }
+
+    override public func string(for obj: Any?) -> String? {
+        guard let date = obj as? Date else { return nil }
+        return localizedString(for: date, relativeTo: .now)
+    }
+
+    private var relativeDateTimeFormatterStyle: android.icu.text.RelativeDateTimeFormatter.Style {
+        // NARROW and SHORT both behave like `UnitsStyle.Abbreviated` as of Android 15
+        // https://developer.android.com/reference/android/icu/text/RelativeDateTimeFormatter.Style#NARROW
+        switch unitsStyle {
+//        case .abbreviated:
+//            android.icu.text.RelativeDateTimeFormatter.Style.NARROW
+        case .short:
+            android.icu.text.RelativeDateTimeFormatter.Style.SHORT
+        default:
+            android.icu.text.RelativeDateTimeFormatter.Style.LONG
+        }
+    }
 }
 
 #endif

--- a/Tests/SkipFoundationTests/Formatters/TestRelativeDateTimeFormatter.swift
+++ b/Tests/SkipFoundationTests/Formatters/TestRelativeDateTimeFormatter.swift
@@ -203,11 +203,13 @@ class TestRelativeDateTimeFormatter: XCTestCase {
         }
     }
 
-    @available(macOS 15, iOS 18, watchOS 11, tvOS 18, *)
     func test_namedAbbreviated() {
         #if SKIP
         throw XCTSkip("TODO")
         #else
+        if !#available(macOS 15, iOS 18, watchOS 11, tvOS 18, *) { 
+            throw XCTSkip("Expected formats presume macOS 15+/iOS 18+ conventions")
+        }
         formatter.dateTimeStyle = .named
         formatter.unitsStyle = .abbreviated
         for (_, _, namedAbbreviated, dateComponents, timeInterval) in customFormatting {

--- a/Tests/SkipFoundationTests/Formatters/TestRelativeDateTimeFormatter.swift
+++ b/Tests/SkipFoundationTests/Formatters/TestRelativeDateTimeFormatter.swift
@@ -1,0 +1,266 @@
+// Copyright 2023 Skip
+//
+// This is free software: you can redistribute and/or modify it
+// under the terms of the GNU Lesser General Public License 3.0
+// as published by the Free Software Foundation https://fsf.org
+import Foundation
+import XCTest
+
+fileprivate typealias CaseRelativeFormat = (numericFull: String, namedShort: String, namedAbbreviated: String, dateComponents: DateComponents, timeInterval: TimeInterval)
+
+/// Kotlin formats time intervals approaching/at 0 as "x ago"
+fileprivate func rel(_ formatString: String, interval: TimeInterval = 0.0) -> String {
+    guard !formatString.isEmpty else { return formatString }
+    #if !SKIP
+    let isPast = interval < 0.0
+    #else
+    let isPast = interval < 1.0
+    #endif
+    return isPast ? "\(formatString) ago" : "in \(formatString)"
+}
+
+class TestRelativeDateTimeFormatter: XCTestCase {
+    let formatter = RelativeDateTimeFormatter()
+    #if !SKIP
+    // `spellOut` is not currently supported in Kotlin
+    let spellOutNumberFormatter = NumberFormatter()
+    #endif
+
+    fileprivate let reversableRelativeTimes: [CaseRelativeFormat] = {
+        [
+            ("1 second",  "1 sec.", "1s",   DateComponents(second: 1), 1.0),
+            ("1 second",  "1 sec.", "1s",   DateComponents(second: 1, nanosecond: 900000000), 1.9),
+            ("2 seconds", "2 sec.", "2s",   DateComponents(year: 0, second: 2), 2.0),
+            ("1 minute",  "1 min.", "1m",   DateComponents(minute: 1), 60.0),
+            ("5 minutes", "5 min.", "5m",   DateComponents(minute: 5), 60.0 * 5.0),
+            ("1 hour",    "1 hr.",  "1h",   DateComponents(hour: 1, minute: 999), 60.0 * 60.0),
+            ("12 hours",  "12 hr.", "12h",  DateComponents(hour: 12), 60.0 * 60.0 * 12.0),
+            ("6 days",    "6 days", "6d",   DateComponents(day: 6), 60.0 * 60.0 * 24.0 * 6.9),
+            ("4 weeks",   "4 wk.",  "4w",   DateComponents(weekOfMonth: 4), 60.0 * 60.0 * 24.0 * 30.9),
+            ("11 months", "11 mo.", "11mo", DateComponents(month: 11), 60.0 * 60.0 * 24.0 * 364.9),
+            ("54 years",  "54 yr.", "54y",  DateComponents(year: 54), 60.0 * 60.0 * 24.0 * 365.0 * 55.0),
+            ("55 years",  "55 yr.", "55y",  DateComponents(year: 55), 60.0 * 60.0 * 24.0 * 366.0 * 55.0),
+        ]
+    }()
+
+    fileprivate let customFormatting: [CaseRelativeFormat] = {
+        [
+            (rel("0 seconds"), "now",        "now",       DateComponents(second: -0), -0.9),
+            ("in 1 day",       "tomorrow",   "tomorrow",  DateComponents(day: 1), 60.0 * 60.0 * 24.0),
+            ("1 day ago",      "yesterday",  "yesterday", DateComponents(day: -1), -60.0 * 60.0 * 24.0),
+            ("in 1 week",      "next wk.",   "next wk.",  DateComponents(weekOfMonth: 1), 60.0 * 60.0 * 24.0 * 7.0),
+            ("1 week ago",     "last wk.",   "last wk.",  DateComponents(day: 1, weekOfMonth: -1), -60.0 * 60.0 * 24.0 * 7.0),
+            ("in 1 month",     "next mo.",   "next mo.",  DateComponents(month: 1), 60.0 * 60.0 * 24.0 * 31.0),
+            ("1 month ago",    "last mo.",   "last mo.",  DateComponents(month: -1), -60.0 * 60.0 * 24.0 * 31.0),
+            ("in 1 year",      "next yr.",   "next yr.",  DateComponents(year: 1), 60.0 * 60.0 * 24.0 * 365.0),
+            ("11 months ago",  "11 mo. ago", "11mo ago",  DateComponents(month: -11), -60.0 * 60.0 * 24.0 * 365.0),
+            ("1 year ago",     "last yr.",   "last yr.",  DateComponents(year: -1), -60.0 * 60.0 * 24.0 * 366.0),
+        ]
+    }()
+
+    fileprivate let customDateComponents: [CaseRelativeFormat] = {
+        #if !SKIP
+        let thisHour = "this hour"
+        #else
+        let thisHour = "0 hr. ago"
+        #endif
+        return [
+            ("", "", "", DateComponents(), 0.0),
+            ("", "", "", DateComponents(nanosecond: 1), 0.0),
+            ("", "", "", DateComponents(weekday: 1), 0.0),
+            ("", "", "", DateComponents(weekdayOrdinal: 1), 0.0),
+            ("", "", "", DateComponents(weekOfYear: 1), 0.0),
+            ("", "", "", DateComponents(yearForWeekOfYear: 1), 0.0),
+            ("", "", "", DateComponents(quarter: 1), 0.0),
+            ("", "", "", DateComponents(era: 1), 0.0),
+            (rel("0 seconds"), "now",       "now",       DateComponents(second: 0), 0.0),
+            ("in 1 minute",    "in 1 min.", "in 1m",     DateComponents(hour: 0, minute: 1), 0.0),
+            (rel("0 hours"),   thisHour,    "this hour", DateComponents(hour: 0), 0.0),
+            (rel("0 days"),    "today",     "today",     DateComponents(day: 0), 0.0),
+        ]
+    }()
+
+    fileprivate let reversableDateComponents: [CaseRelativeFormat] = {
+        [
+            ("55 days",  "55 days", "55d", DateComponents(day: 55, hour: 56), 1.0),
+            ("8 weeks",  "8 wk.",   "8w",  DateComponents(weekOfMonth: 8), 1.0),
+            ("55 weeks", "55 wk.",  "55w", DateComponents(weekOfMonth: 55), 1.0),
+        ]
+    }()
+
+    override func setUp() {
+        formatter.locale = Locale(identifier: "en_US")
+        #if !SKIP
+        formatter.calendar = Calendar(identifier: .gregorian)
+        spellOutNumberFormatter.locale = formatter.locale
+        spellOutNumberFormatter.numberStyle = .spellOut
+        #endif
+        super.setUp()
+    }
+
+    func test_defaults() {
+        let unconfigured = RelativeDateTimeFormatter()
+        XCTAssertEqual(unconfigured.dateTimeStyle, .numeric)
+        XCTAssertEqual(unconfigured.unitsStyle, .full)
+
+        formatter.dateTimeStyle = .named
+        XCTAssertNil(formatter.string(for: 1.0 as TimeInterval))
+        XCTAssertNil(formatter.string(for: DateComponents(second: 0)))
+        XCTAssertEqual(formatter.string(for: Date(timeIntervalSinceNow: 0)), "now")
+    }
+
+    func test_numericFull() {
+        formatter.dateTimeStyle = .numeric
+        formatter.unitsStyle = .full
+        XCTAssertEqual(formatter.localizedString(from: DateComponents(day: 1, hour: 1)), "in 1 day")
+        for (numericFull, _, _, dateComponents, timeInterval) in customFormatting {
+            XCTAssertEqual(formatter.localizedString(fromTimeInterval: timeInterval), numericFull)
+            XCTAssertEqual(formatter.localizedString(from: dateComponents), numericFull)
+        }
+        for (numericFull, _, _, dateComponents, _) in customDateComponents {
+            XCTAssertEqual(formatter.localizedString(from: dateComponents), numericFull)
+        }
+        for direction in [-1, 1] {
+            for (numericFull, _, _, dateComponents, timeInterval) in reversableRelativeTimes {
+                let (timeInterval, dateComponents, numericFull) = applyReversable(interval: timeInterval, components: dateComponents, direction: direction, formatString: numericFull)
+                XCTAssertEqual(formatter.localizedString(fromTimeInterval: timeInterval), numericFull)
+                XCTAssertEqual(formatter.localizedString(from: dateComponents), numericFull)
+            }
+            for (numericFull, _, _, dateComponents, timeInterval) in reversableDateComponents {
+                let (_, dateComponents, numericFull) = applyReversable(interval: timeInterval, components: dateComponents, direction: direction, formatString: numericFull)
+                XCTAssertEqual(formatter.localizedString(from: dateComponents), numericFull)
+            }
+        }
+    }
+
+    func test_numericSpelledOut() {
+        #if SKIP
+        throw XCTSkip("TODO")
+        #else
+        formatter.dateTimeStyle = .numeric
+        formatter.unitsStyle = .spellOut
+        for (numericFull, _, _, dateComponents, timeInterval) in customFormatting {
+            let numericSpelledOut = spellOutNumbers(numericFull)
+            XCTAssertEqual(formatter.localizedString(fromTimeInterval: timeInterval), numericSpelledOut)
+            XCTAssertEqual(formatter.localizedString(from: dateComponents), numericSpelledOut)
+        }
+        for (numericFull, _, _, dateComponents, _) in customDateComponents {
+            let numericSpelledOut = spellOutNumbers(numericFull)
+            XCTAssertEqual(formatter.localizedString(from: dateComponents), numericSpelledOut)
+        }
+        for direction in [-1, 1] {
+            for (numericFull, _, _, dateComponents, timeInterval) in reversableRelativeTimes {
+                let (timeInterval, dateComponents, numericFull) = applyReversable(interval: timeInterval, components: dateComponents, direction: direction, formatString: numericFull)
+                let numericSpelledOut = spellOutNumbers(numericFull)
+                XCTAssertEqual(formatter.localizedString(fromTimeInterval: timeInterval), numericSpelledOut)
+                XCTAssertEqual(formatter.localizedString(from: dateComponents), numericSpelledOut)
+            }
+            for (numericFull, _, _, dateComponents, timeInterval) in reversableDateComponents {
+                let (_, dateComponents, numericFull) = applyReversable(interval: timeInterval, components: dateComponents, direction: direction, formatString: numericFull)
+                let numericSpelledOut = spellOutNumbers(numericFull)
+                XCTAssertEqual(formatter.localizedString(from: dateComponents), numericSpelledOut)
+            }
+        }
+        #endif
+    }
+
+    func test_namedShort() {
+        formatter.dateTimeStyle = .named
+        formatter.unitsStyle = .short
+        for (_, namedShort, _, dateComponents, timeInterval) in customFormatting {
+            XCTAssertEqual(formatter.localizedString(fromTimeInterval: timeInterval), namedShort)
+            XCTAssertEqual(formatter.localizedString(from: dateComponents), namedShort)
+        }
+        for (_, namedShort, _, dateComponents, _) in customDateComponents {
+            XCTAssertEqual(formatter.localizedString(from: dateComponents), namedShort)
+        }
+        for direction in [-1, 1] {
+            for (_, namedShort, _, dateComponents, timeInterval) in reversableRelativeTimes {
+                let (timeInterval, dateComponents, namedShort) = applyReversable(interval: timeInterval, components: dateComponents, direction: direction, formatString: namedShort)
+                XCTAssertEqual(formatter.localizedString(fromTimeInterval: timeInterval), namedShort)
+                XCTAssertEqual(formatter.localizedString(from: dateComponents), namedShort)
+            }
+            for (_, namedShort, _, dateComponents, timeInterval) in reversableDateComponents {
+                let (_, dateComponents, namedShort) = applyReversable(interval: timeInterval, components: dateComponents, direction: direction, formatString: namedShort)
+                XCTAssertEqual(formatter.localizedString(from: dateComponents), namedShort)
+            }
+        }
+    }
+
+    func test_namedAbbreviated() {
+        #if SKIP
+        throw XCTSkip("TODO")
+        #else
+        formatter.dateTimeStyle = .named
+        formatter.unitsStyle = .abbreviated
+        for (_, _, namedAbbreviated, dateComponents, timeInterval) in customFormatting {
+            XCTAssertEqual(formatter.localizedString(fromTimeInterval: timeInterval), namedAbbreviated)
+            XCTAssertEqual(formatter.localizedString(from: dateComponents), namedAbbreviated)
+        }
+        for (_, _, namedAbbreviated, dateComponents, _) in customDateComponents {
+            XCTAssertEqual(formatter.localizedString(from: dateComponents), namedAbbreviated)
+        }
+        for direction in [-1, 1] {
+            for (_, _, namedAbbreviated, dateComponents, timeInterval) in reversableRelativeTimes {
+                let (timeInterval, dateComponents, namedAbbreviated) = applyReversable(interval: timeInterval, components: dateComponents, direction: direction, formatString: namedAbbreviated)
+                XCTAssertEqual(formatter.localizedString(fromTimeInterval: timeInterval), namedAbbreviated)
+                XCTAssertEqual(formatter.localizedString(from: dateComponents), namedAbbreviated)
+            }
+            for (_, _, namedAbbreviated, dateComponents, timeInterval) in reversableDateComponents {
+                let (_, dateComponents, namedAbbreviated) = applyReversable(interval: timeInterval, components: dateComponents, direction: direction, formatString: namedAbbreviated)
+                XCTAssertEqual(formatter.localizedString(from: dateComponents), namedAbbreviated)
+            }
+        }
+        #endif
+    }
+
+    fileprivate func spellOutNumbers(_ formatString: String) -> String {
+        #if !SKIP
+        return formatString
+            .split(separator: " ").map {
+                let word = String($0)
+                guard let int = Int(word) else { return word }
+                return spellOutNumberFormatter.string(from: int as NSNumber) ?? word
+            }
+            .joined(separator: " ")
+        #else
+        return formatString
+        #endif
+    }
+
+    fileprivate func applyReversable(interval: TimeInterval, components: DateComponents, direction: Int, formatString: String) -> (TimeInterval, DateComponents, String) {
+        let timeInterval = interval * Double(direction)
+        let formattedString = rel(formatString, interval: timeInterval)
+        var components = components
+        if timeInterval < 0 {
+            if components.year != nil {
+                components.year = components.year! * -1
+            }
+            if components.month != nil {
+                components.month = components.month! * -1
+            }
+            if components.weekOfMonth != nil {
+                components.weekOfMonth = components.weekOfMonth! * -1
+            }
+            if components.day != nil {
+                components.day = components.day! * -1
+            }
+            if components.hour != nil {
+                components.hour = components.hour! * -1
+            }
+            if components.minute != nil {
+                components.minute = components.minute! * -1
+            }
+            if components.second != nil {
+                components.second = components.second! * -1
+            }
+            if components.nanosecond != nil {
+                components.nanosecond = components.nanosecond! * -1
+            }
+            if components.weekday != nil {
+                components.weekday = components.weekday! * -1
+            }
+        }
+        return (timeInterval, components, formattedString)
+    }
+}

--- a/Tests/SkipFoundationTests/Formatters/TestRelativeDateTimeFormatter.swift
+++ b/Tests/SkipFoundationTests/Formatters/TestRelativeDateTimeFormatter.swift
@@ -203,6 +203,7 @@ class TestRelativeDateTimeFormatter: XCTestCase {
         }
     }
 
+    @available(macOS 15, iOS 18, watchOS 11, tvOS 18, *)
     func test_namedAbbreviated() {
         #if SKIP
         throw XCTSkip("TODO")

--- a/Tests/SkipFoundationTests/Formatters/TestRelativeDateTimeFormatter.swift
+++ b/Tests/SkipFoundationTests/Formatters/TestRelativeDateTimeFormatter.swift
@@ -205,7 +205,7 @@ class TestRelativeDateTimeFormatter: XCTestCase {
 
     private func platformAbbreviatedOutputFormat(abbreviated: String, short: String) -> String {
         #if !SKIP
-        if #available(macOS 15, iOS 18, watchOS 11, tvOS 18, *) {
+        if #available(macOS 14, iOS 17, watchOS 10, tvOS 17, *) {
             return abbreviated
         }
         #endif

--- a/Tests/SkipFoundationTests/Formatters/TestRelativeDateTimeFormatter.swift
+++ b/Tests/SkipFoundationTests/Formatters/TestRelativeDateTimeFormatter.swift
@@ -109,6 +109,22 @@ class TestRelativeDateTimeFormatter: XCTestCase {
         XCTAssertEqual(formatter.string(for: Date(timeIntervalSinceNow: 0)), "now")
     }
 
+    func test_formattingContext() {
+        formatter.dateTimeStyle = .named
+        formatter.formattingContext = .beginningOfSentence
+        XCTAssertEqual(formatter.localizedString(fromTimeInterval: 0), "Now")
+        formatter.formattingContext = .listItem
+        XCTAssertEqual(formatter.localizedString(fromTimeInterval: 0), "now")
+//        formatter.formattingContext = .dynamic
+//        XCTAssertEqual(formatter.attributedString(for: Date.now, withDefaultAttributes: nil), NSAttributedString("now"))
+        formatter.formattingContext = .middleOfSentence
+        XCTAssertEqual(formatter.localizedString(fromTimeInterval: 0), "now")
+        formatter.formattingContext = .standalone
+        XCTAssertEqual(formatter.localizedString(fromTimeInterval: 0), "now")
+        formatter.formattingContext = .unknown
+        XCTAssertEqual(formatter.localizedString(fromTimeInterval: 0), "now")
+    }
+
     func test_numericFull() {
         formatter.dateTimeStyle = .numeric
         formatter.unitsStyle = .full

--- a/Tests/SkipFoundationTests/Formatters/TestRelativeDateTimeFormatter.swift
+++ b/Tests/SkipFoundationTests/Formatters/TestRelativeDateTimeFormatter.swift
@@ -203,30 +203,40 @@ class TestRelativeDateTimeFormatter: XCTestCase {
         }
     }
 
+    private func platformAbbreviatedOutputFormat(abbreviated: String, short: String) -> String {
+        #if !SKIP
+        if #available(macOS 15, iOS 18, watchOS 11, tvOS 18, *) {
+            return abbreviated
+        }
+        #endif
+        return short
+    }
+
     func test_namedAbbreviated() {
         #if SKIP
         throw XCTSkip("TODO")
         #else
-        if !#available(macOS 15, iOS 18, watchOS 11, tvOS 18, *) { 
-            throw XCTSkip("Expected formats presume macOS 15+/iOS 18+ conventions")
-        }
         formatter.dateTimeStyle = .named
         formatter.unitsStyle = .abbreviated
-        for (_, _, namedAbbreviated, dateComponents, timeInterval) in customFormatting {
+        for (_, namedShort, namedAbbreviated, dateComponents, timeInterval) in customFormatting {
+            let namedAbbreviated = platformAbbreviatedOutputFormat(abbreviated: namedAbbreviated, short: namedShort)
             XCTAssertEqual(formatter.localizedString(fromTimeInterval: timeInterval), namedAbbreviated)
             XCTAssertEqual(formatter.localizedString(from: dateComponents), namedAbbreviated)
         }
-        for (_, _, namedAbbreviated, dateComponents, _) in customDateComponents {
+        for (_, namedShort, namedAbbreviated, dateComponents, _) in customDateComponents {
+            let namedAbbreviated = platformAbbreviatedOutputFormat(abbreviated: namedAbbreviated, short: namedShort)
             XCTAssertEqual(formatter.localizedString(from: dateComponents), namedAbbreviated)
         }
         for direction in [-1, 1] {
-            for (_, _, namedAbbreviated, dateComponents, timeInterval) in reversableRelativeTimes {
-                let (timeInterval, dateComponents, namedAbbreviated) = applyReversable(interval: timeInterval, components: dateComponents, direction: direction, formatString: namedAbbreviated)
+            for (_, namedShort, _namedAbbreviated, dateComponents, timeInterval) in reversableRelativeTimes {
+                let _namedAbbreviated = platformAbbreviatedOutputFormat(abbreviated: _namedAbbreviated, short: namedShort)
+                let (timeInterval, dateComponents, namedAbbreviated) = applyReversable(interval: timeInterval, components: dateComponents, direction: direction, formatString: _namedAbbreviated)
                 XCTAssertEqual(formatter.localizedString(fromTimeInterval: timeInterval), namedAbbreviated)
                 XCTAssertEqual(formatter.localizedString(from: dateComponents), namedAbbreviated)
             }
-            for (_, _, namedAbbreviated, dateComponents, timeInterval) in reversableDateComponents {
-                let (_, dateComponents, namedAbbreviated) = applyReversable(interval: timeInterval, components: dateComponents, direction: direction, formatString: namedAbbreviated)
+            for (_, namedShort, _namedAbbreviated, dateComponents, timeInterval) in reversableDateComponents {
+                let _namedAbbreviated = platformAbbreviatedOutputFormat(abbreviated: _namedAbbreviated, short: namedShort)
+                let (_, dateComponents, namedAbbreviated) = applyReversable(interval: timeInterval, components: dateComponents, direction: direction, formatString: _namedAbbreviated)
                 XCTAssertEqual(formatter.localizedString(from: dateComponents), namedAbbreviated)
             }
         }


### PR DESCRIPTION
Closes #16 

- Adds `Formatter.Context` to control capitalization
- Does not support `UnitsStyle.spellOut`
- Does not support `UnitsStyle.abbreviated`; for some reason the docs describe `android.icu.text.RelativeDateTimeFormatter.Style.NARROW` as matching the desired behavior but it seems to produce the same output as `android.icu.text.RelativeDateTimeFormatter.Style.SHORT`
- Does not support `calendar`; I'm not sure how this would be used
- `localizedString(from dateComponents:)` and `localizedString(fromTimeInterval timeInterval:)` are a bit repetitive, but there ended up being enough differences I kept their implementations separate

---

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device