### PR TITLE
Support JSON encoding/decoding of Decimal

### DIFF
--- a/Sources/SkipFoundation/JSONDecoder.swift
+++ b/Sources/SkipFoundation/JSONDecoder.swift
@@ -237,8 +237,13 @@ private struct JSONDecoderImpl: Decoder {
 
     private func unwrapDecimal() throws -> Decimal {
         let container = JSONSingleValueDecodingContainer(impl: self, codingPath: self.codingPath, json: self.json)
-        let double = try container.decode(Double.self)
-        return Decimal(double)
+        do {
+            let string = try container.decode(String.self)
+            return Decimal(string)
+        } catch {
+            let double = try container.decode(Double.self)
+            return Decimal(double)
+        }
     }
 
     private func unwrapDate() throws -> Date {

--- a/Sources/SkipFoundation/JSONDecoder.swift
+++ b/Sources/SkipFoundation/JSONDecoder.swift
@@ -222,6 +222,9 @@ private struct JSONDecoderImpl: Decoder {
         if type == URL.self {
             return try self.unwrapURL() as! T
         }
+        if type == Decimal.self {
+            return try self.unwrapDecimal() as! T
+        }
 
         /* SKIP INSERT:
         val decodableCompanion = type.companionObjectInstance as? DecodableCompanion<*>
@@ -230,6 +233,12 @@ private struct JSONDecoderImpl: Decoder {
         }
         */
         throw createTypeMismatchError(type: Decodable.self, value: self.json)
+    }
+
+    private func unwrapDecimal() throws -> Decimal {
+        let container = JSONSingleValueDecodingContainer(impl: self, codingPath: self.codingPath, json: self.json)
+        let double = try container.decode(Double.self)
+        return Decimal(double)
     }
 
     private func unwrapDate() throws -> Date {

--- a/Sources/SkipFoundation/JSONEncoder.swift
+++ b/Sources/SkipFoundation/JSONEncoder.swift
@@ -352,6 +352,8 @@ extension JSONEncoderImpl: _SpecialTreatmentEncoder {
             return try self.wrapData(data, for: nil)
         case let url as URL:
             return .string(url.absoluteString)
+        case let decimal as Decimal:
+            return .number(decimal.toPlainString())
         default:
             try encodable.encode(to: self)
             return self.value ?? .object([:])
@@ -385,6 +387,8 @@ extension _SpecialTreatmentEncoder {
             return try self.wrapData(data, for: additionalKey)
         case let url as URL:
             return .string(url.absoluteString)
+        case let decimal as Decimal:
+            return .number(decimal.toPlainString())
         default:
             let encoder = self.getEncoder(for: additionalKey)
             // SKIP REPLACE: (encodable as Encodable).encode(encoder)

--- a/Sources/SkipFoundation/Number.swift
+++ b/Sources/SkipFoundation/Number.swift
@@ -44,6 +44,14 @@ public func NSNumber(_ v: UInt64, unusedp: ()? = nil) -> NSNumber { v as NSNumbe
 public func NSNumber(_ v: Float, unusedp: ()? = nil) -> NSNumber { v as NSNumber }
 public func NSNumber(_ v: Double, unusedp: ()? = nil) -> NSNumber { v as NSNumber }
 
+public func Decimal(string: String, locale: Locale? = nil) -> Decimal? {
+    do {
+        return java.math.BigDecimal(string)
+    } catch { // NumberFormatException - if val is not a valid representation of a BigDecimal.
+        return nil
+    }
+}
+
 public extension java.math.BigDecimal {
 //    static let zero = java.math.BigDecimal(0)
 //    static let pi = java.math.BigDecimal("3.14159265358979323846264338327950288419")

--- a/Sources/SkipFoundation/Number.swift
+++ b/Sources/SkipFoundation/Number.swift
@@ -44,4 +44,12 @@ public func NSNumber(_ v: UInt64, unusedp: ()? = nil) -> NSNumber { v as NSNumbe
 public func NSNumber(_ v: Float, unusedp: ()? = nil) -> NSNumber { v as NSNumber }
 public func NSNumber(_ v: Double, unusedp: ()? = nil) -> NSNumber { v as NSNumber }
 
+public extension java.math.BigDecimal {
+//    static let zero = java.math.BigDecimal(0)
+//    static let pi = java.math.BigDecimal("3.14159265358979323846264338327950288419")
+//
+//    @available(*, unavailable)
+//    static let nan = java.math.BigDecimal(0) // BigDecimal class provides no representation of nan
+}
+
 #endif

--- a/Tests/SkipFoundationTests/CoreLibs/TestDecimal.swift
+++ b/Tests/SkipFoundationTests/CoreLibs/TestDecimal.swift
@@ -190,17 +190,19 @@ class TestDecimal: XCTestCase {
     }
 
     func test_Description() {
-        #if SKIP
-        throw XCTSkip("TODO")
-        #else
         XCTAssertEqual("0", Decimal().description)
         XCTAssertEqual("0", Decimal(0).description)
-        XCTAssertEqual("10", Decimal(_exponent: 1, _length: 1, _isNegative: 0, _isCompact: 1, _reserved: 0, _mantissa: (1, 0, 0, 0, 0, 0, 0, 0)).description)
         XCTAssertEqual("10", Decimal(10).description)
-        XCTAssertEqual("123.458", Decimal(_exponent: -3, _length: 2, _isNegative: 0, _isCompact:1, _reserved: 0, _mantissa: (57922, 1, 0, 0, 0, 0, 0, 0)).description)
         XCTAssertEqual("123.458", Decimal(123.458).description)
         XCTAssertEqual("123", Decimal(UInt8(123)).description)
         XCTAssertEqual("45", Decimal(Int8(45)).description)
+
+        #if SKIP
+        throw XCTSkip("No NSDecimalNumber in Skip")
+        #else
+        XCTAssertEqual("10", Decimal(_exponent: 1, _length: 1, _isNegative: 0, _isCompact: 1, _reserved: 0, _mantissa: (1, 0, 0, 0, 0, 0, 0, 0)).description)
+        XCTAssertEqual("123.458", Decimal(_exponent: -3, _length: 2, _isNegative: 0, _isCompact:1, _reserved: 0, _mantissa: (57922, 1, 0, 0, 0, 0, 0, 0)).description)
+
         XCTAssertEqual("3.14159265358979323846264338327950288419", Decimal.pi.description)
         XCTAssertEqual("-30000000000", Decimal(sign: .minus, exponent: 10, significand: Decimal(3)).description)
         XCTAssertEqual("300000", Decimal(sign: .plus, exponent: 5, significand: Decimal(3)).description)
@@ -208,6 +210,7 @@ class TestDecimal: XCTestCase {
         XCTAssertEqual("-5", Decimal(signOf: Decimal(-3), magnitudeOf: Decimal(5)).description)
         XCTAssertEqual("5", Decimal(signOf: Decimal(3), magnitudeOf: Decimal(-5)).description)
         XCTAssertEqual("-5", Decimal(signOf: Decimal(-3), magnitudeOf: Decimal(-5)).description)
+        
         XCTAssertEqual("5", NSDecimalNumber(decimal: Decimal(5)).description)
         XCTAssertEqual("-5", NSDecimalNumber(decimal: Decimal(-5)).description)
         XCTAssertEqual("3402823669209384634633746074317682114550000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", Decimal.greatestFiniteMagnitude.description)

--- a/Tests/SkipFoundationTests/Formatters/TestISO8601DateFormatter.swift
+++ b/Tests/SkipFoundationTests/Formatters/TestISO8601DateFormatter.swift
@@ -191,6 +191,26 @@ class TestISO8601DateFormatter: XCTestCase {
 
         result = f.date(from: "12345")
         XCTAssertNil(result)
+
+
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        result = f.date(from: "2025-01-11T15:30:24.390+00:00")
+        XCTAssertNotNil(result)
+        if let stringResult = result?.description {
+            XCTAssertEqual(stringResult, "2025-01-11 15:30:24 +0000")
+        }
+
+        result = f.date(from: "2025-01-11T15:30:24.1+00:00")
+        XCTAssertNotNil(result)
+        if let stringResult = result?.description {
+            XCTAssertEqual(stringResult, "2025-01-11 15:30:24 +0000")
+        }
+
+        result = f.date(from: "2025-01-11T15:30:24.390858+00:00")
+        XCTAssertNotNil(result)
+        if let stringResult = result?.description {
+            XCTAssertEqual(stringResult, "2025-01-11 15:30:24 +0000")
+        }
     }
 
 

--- a/Tests/SkipFoundationTests/Foundation/JSONTests.swift
+++ b/Tests/SkipFoundationTests/Foundation/JSONTests.swift
@@ -289,7 +289,10 @@ class TestJSON : XCTestCase {
         XCTAssertEqual(#"{"decimalField":0}"#, try roundtrip(value: DecimalField(decimalField: Decimal(0))))
         XCTAssertEqual(#"{"decimalField":1}"#, try roundtrip(value: DecimalField(decimalField: Decimal(1))))
         XCTAssertEqual(#"{"decimalField":-1}"#, try roundtrip(value: DecimalField(decimalField: Decimal(-1))))
+
         XCTAssertEqual(#"{"decimalField":1234567890987654321}"#, try roundtrip(value: DecimalField(decimalField: Decimal(1234567890987654321)), checkeq: false))
+        XCTAssertEqual(#"{"decimalField":1234567890987654321}"#, try roundtrip(value: DecimalField(decimalField: Decimal(string: "1234567890987654321")!), checkeq: false))
+
         #if SKIP
         XCTAssertEqual(#"{"decimalField":0.00000000000010000000000000000303737455634003709136034716842278413651001756079494953155517578125}"#, try roundtrip(value: DecimalField(decimalField: Decimal(0.0000000000001)), checkeq: false))
         #else
@@ -297,12 +300,18 @@ class TestJSON : XCTestCase {
         #endif
         //XCTAssertEqual(#"{"decimalField":0}"#, try roundtrip(value: DecimalField(decimalField: Decimal.nan))) // BigDecimal cannot represent nan
 
-        let onePointTwo = DecimalField(decimalField: Decimal(1.2))
+        let onePointTwoString = DecimalField(decimalField: try XCTUnwrap(Decimal(string: "1.2")))
+        XCTAssertEqual(#"{"decimalField":1.2}"#, try roundtrip(value: onePointTwoString))
+
+        let onePointTwoDouble = DecimalField(decimalField: Decimal(1.2))
         #if SKIP
-        XCTAssertEqual(#"{"decimalField":1.1999999999999999555910790149937383830547332763671875}"#, try roundtrip(value: onePointTwo))
+        XCTAssertEqual(#"{"decimalField":1.1999999999999999555910790149937383830547332763671875}"#, try roundtrip(value: onePointTwoDouble, checkeq: false))
         #else
-        XCTAssertEqual(#"{"decimalField":1.2}"#, try roundtrip(value: onePointTwo))
+        XCTAssertEqual(#"{"decimalField":1.2}"#, try roundtrip(value: onePointTwoDouble))
         #endif
+
+        let decimalPiString = try XCTUnwrap(Decimal(string: "3.14159"))
+        XCTAssertEqual(#"{"decimalField":3.14159}"#, try roundtrip(value: DecimalField(decimalField: decimalPiString)))
 
         let decimalPiShort = Decimal(3.14159)
         #if SKIP

--- a/Tests/SkipFoundationTests/Foundation/JSONTests.swift
+++ b/Tests/SkipFoundationTests/Foundation/JSONTests.swift
@@ -31,6 +31,10 @@ class TestJSON : XCTestCase {
         var doubleField: Double
     }
 
+    struct DecimalField : Equatable, Codable {
+        var decimalField: Decimal
+    }
+
     struct DataField : Equatable, Codable {
         var dataField: Data
     }
@@ -225,7 +229,7 @@ class TestJSON : XCTestCase {
     }
 
     /// Round-trip a type
-    @inline(__always) private func roundtrip<T>(value: T, fmt: JSONEncoder.OutputFormatting? = .sortedKeys, data: JSONEncoder.DataEncodingStrategy? = nil, date: JSONEncoder.DateEncodingStrategy? = nil, floats: JSONEncoder.NonConformingFloatEncodingStrategy? = nil, keys: JSONEncoder.KeyEncodingStrategy? = nil, dkeys: JSONDecoder.KeyDecodingStrategy? = nil) throws -> String where T : Encodable, T : Decodable, T : Equatable {
+    @inline(__always) private func roundtrip<T>(value: T, fmt: JSONEncoder.OutputFormatting? = .sortedKeys, data: JSONEncoder.DataEncodingStrategy? = nil, date: JSONEncoder.DateEncodingStrategy? = nil, floats: JSONEncoder.NonConformingFloatEncodingStrategy? = nil, keys: JSONEncoder.KeyEncodingStrategy? = nil, dkeys: JSONDecoder.KeyDecodingStrategy? = nil, checkeq: Bool = true) throws -> String where T : Encodable, T : Decodable, T : Equatable {
         let json = try enc(value, fmt: fmt, data: data, date: date, floats: floats, keys: keys)
 
         let decoder = JSONDecoder()
@@ -233,7 +237,9 @@ class TestJSON : XCTestCase {
             decoder.keyDecodingStrategy = dkeys
         }
         let value2 = try decoder.decode(T.self, from: json.data(using: String.Encoding.utf8)!)
-        XCTAssertEqual(value, value2)
+        if checkeq {
+            XCTAssertEqual(value, value2, "roundtripped value did not match through JSON: \(json)")
+        }
 
         return json
     }
@@ -279,6 +285,39 @@ class TestJSON : XCTestCase {
         XCTAssertEqual(#"{"boolArrayField":[false,true]}"#, try roundtrip(value: BoolArrayField(boolArrayField: [false,true])))
         XCTAssertEqual(#"{"boolArrayArrayField":[[false,true]]}"#, try enc(BoolArrayArrayField(boolArrayArrayField: [[false,true]])))
         XCTAssertEqual(#"{"boolArrayArrayArrayField":[[[false,true],[false,true]],[[false,true],[false,true]]]}"#, try enc(BoolArrayArrayArrayField(boolArrayArrayArrayField: [[[false,true],[false,true]],[[false,true],[false,true]]])))
+
+        XCTAssertEqual(#"{"decimalField":0}"#, try roundtrip(value: DecimalField(decimalField: Decimal(0))))
+        XCTAssertEqual(#"{"decimalField":1}"#, try roundtrip(value: DecimalField(decimalField: Decimal(1))))
+        XCTAssertEqual(#"{"decimalField":-1}"#, try roundtrip(value: DecimalField(decimalField: Decimal(-1))))
+        XCTAssertEqual(#"{"decimalField":1234567890987654321}"#, try roundtrip(value: DecimalField(decimalField: Decimal(1234567890987654321)), checkeq: false))
+        #if SKIP
+        XCTAssertEqual(#"{"decimalField":0.00000000000010000000000000000303737455634003709136034716842278413651001756079494953155517578125}"#, try roundtrip(value: DecimalField(decimalField: Decimal(0.0000000000001)), checkeq: false))
+        #else
+        XCTAssertEqual(#"{"decimalField":0.00000000000009999999999999997952}"#, try roundtrip(value: DecimalField(decimalField: Decimal(0.0000000000001))))
+        #endif
+        //XCTAssertEqual(#"{"decimalField":0}"#, try roundtrip(value: DecimalField(decimalField: Decimal.nan))) // BigDecimal cannot represent nan
+
+        let onePointTwo = DecimalField(decimalField: Decimal(1.2))
+        #if SKIP
+        XCTAssertEqual(#"{"decimalField":1.1999999999999999555910790149937383830547332763671875}"#, try roundtrip(value: onePointTwo))
+        #else
+        XCTAssertEqual(#"{"decimalField":1.2}"#, try roundtrip(value: onePointTwo))
+        #endif
+
+        let decimalPiShort = Decimal(3.14159)
+        #if SKIP
+        XCTAssertEqual(#"{"decimalField":3.14158999999999988261834005243144929409027099609375}"#, try roundtrip(value: DecimalField(decimalField: decimalPiShort), checkeq: false))
+        #else
+        XCTAssertEqual(#"{"decimalField":3.14159}"#, try roundtrip(value: DecimalField(decimalField: decimalPiShort)))
+        #endif
+
+        let decimalPiLong = Decimal(3.14159265358979323846264338327950288419)
+        // common up to 3.141592653589793
+        #if SKIP
+        XCTAssertEqual(#"{"decimalField":3.141592653589793115997963468544185161590576171875}"#, try roundtrip(value: DecimalField(decimalField: decimalPiLong), checkeq: false))
+        #else
+        XCTAssertEqual(#"{"decimalField":3.141592653589793792}"#, try roundtrip(value: DecimalField(decimalField: decimalPiLong)))
+        #endif
 
         XCTAssertEqual(#"{}"#, try roundtrip(value: EmptyField()))
 


### PR DESCRIPTION
This PR enhanced Decimal support:

- Decimal properties can now be encoded and decoded
- Implement `Decimal(string: String)`
- Add more test cases for Decimal behavior