### PR TITLE
Proposal to add URL -> android.net.Uri conversion helper

### DIFF
--- a/Sources/SkipFoundation/Data.swift
+++ b/Sources/SkipFoundation/Data.swift
@@ -91,7 +91,7 @@ public struct Data : DataProtocol, Hashable, CustomStringConvertible, Codable, K
 
     public init(contentsOf url: URL, options: Data.ReadingOptions = []) throws {
         if url.scheme == "content" {
-            let uri = android.net.Uri.parse(url.absoluteString)
+            let uri = url.toAndroidUri()
             if let inputStream = ProcessInfo.processInfo.androidContext.getContentResolver().openInputStream(uri) {
                 self.platformValue = inputStream.readAllBytes()
                 do { inputStream.close() } catch {}
@@ -320,7 +320,7 @@ public struct Data : DataProtocol, Hashable, CustomStringConvertible, Codable, K
 
         @available(*, unavailable)
         public static let uncached = ReadingOptions(rawValue: 2)
-        
+
         @available(*, unavailable)
         public static let alwaysMapped = ReadingOptions(rawValue: 4)
     }

--- a/Sources/SkipFoundation/URL.swift
+++ b/Sources/SkipFoundation/URL.swift
@@ -220,6 +220,11 @@ public struct URL : Hashable, CustomStringConvertible, Codable, KotlinConverting
         return java.nio.file.Paths.get(absoluteURL.platformValue)
     }
 
+    /// Converts this URL to a `android.net.Uri`.
+    public func toAndroidUri() -> android.net.Uri {
+        return android.net.Uri.parse(absoluteString)
+    }
+
     public var host: String? {
         return absoluteURL.platformValue.host
     }

--- a/Sources/SkipFoundation/URLSessionTask.swift
+++ b/Sources/SkipFoundation/URLSessionTask.swift
@@ -58,7 +58,7 @@ public class URLSessionTask {
 
     public var countOfBytesClientExpectsToReceive = Int64(-1)
     public var countOfBytesClientExpectsToSend = Int64(-1)
-    
+
     @available(*, unavailable)
     public let progress: Any? = nil /* Progress(totalUnitCount: -1) */
 
@@ -396,7 +396,7 @@ public class URLSessionWebSocketTask : URLSessionTask {
     }
 
     public var maximumMessageSize: Int = 1 * 1024 * 1024
-    
+
     public var closeCode: CloseCode {
         return lock.withLock { _closeCode } ?? .invalid
     }
@@ -775,7 +775,7 @@ private func contentResponse(for request: URLRequest, with url: URL, isForRespon
         }
         var inputStream: java.io.InputStream? = nil
         return withTaskCancellationHandler {
-            let uri = android.net.Uri.parse(url.absoluteString)
+            let uri = url.toAndroidUri()
             let outputStream = java.io.ByteArrayOutputStream()
             inputStream = ProcessInfo.processInfo.androidContext.getContentResolver().openInputStream(uri)
             if let inputStream {


### PR DESCRIPTION
I would like to propose adding a public method to `URL` that converts to a `android.net.Uri`. The platformValue is `java.net.URI`, but many APIs require the former type. `toPath` is analogous for converting to `java.nio.file.Path`.

This conversion is done slightly inconsistently in skip frameworks (see https://github.com/search?q=org%3Askiptools%20Uri.parse&type=code), so it could be good to standardize. I also use this in my app to pass a URL to Android-specific file APIs, so I think it would be helpful to have available publicly.

---

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device