### PR TITLE
Fix DataTests

### DIFF
--- a/Tests/SkipFoundationTests/Foundation/DataTests.swift
+++ b/Tests/SkipFoundationTests/Foundation/DataTests.swift
@@ -21,7 +21,7 @@ final class DataTests: XCTestCase {
         //logger.log("downloaded url size: \(urlData.count)") // ~1256
         XCTAssertNotEqual(0, urlData.count)
 
-        let url2 = try XCTUnwrap(URL(string: "domains/reserved", relativeTo: URL(string: "https://www.iana.org")))
+        let url2 = try XCTUnwrap(URL(string: "domains/reserved", relativeTo: URL(string: "https://www.iana.org/")))
         let url2Data: Data = try Data(contentsOf: url2)
 
         //logger.log("downloaded url2 size: \(url2Data.count)") // ~1256


### PR DESCRIPTION
Fixes #68

I think there may be a "real" bug here that Robolectric doesn't absolutize URLs properly when the base URL doesn't end with a slash. But I think that's not the purpose of _this_ test, so I'm just working around it by adding a slash.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

