### PR TITLE
Bugfix: URLSessionConfiguration.requestCachePolicy was not taken into account

### DIFF
--- a/Sources/SkipFoundation/URLSessionTask.swift
+++ b/Sources/SkipFoundation/URLSessionTask.swift
@@ -685,7 +685,12 @@ private func httpRequest(for request: URLRequest, with url: URL, configuration: 
     if let headerMap = request.allHTTPHeaderFields?.kotlin(nocopy: true) as? Map<String, String> {
         builder.headers(headerMap.toHeaders())
     }
-    switch request.cachePolicy {
+    
+    let effectivePolicy =
+        request.cachePolicy == URLRequest.CachePolicy.useProtocolCachePolicy
+            ? configuration.requestCachePolicy
+            : request.cachePolicy
+    switch effectivePolicy {
     case URLRequest.CachePolicy.useProtocolCachePolicy:
         break
     case URLRequest.CachePolicy.returnCacheDataElseLoad:
@@ -694,9 +699,9 @@ private func httpRequest(for request: URLRequest, with url: URL, configuration: 
         builder.cacheControl(CacheControl.FORCE_CACHE)
     case URLRequest.CachePolicy.reloadRevalidatingCacheData:
         builder.header("Cache-Control", "no-cache, must-revalidate")
-    case URLRequest.CachePolicy.reloadIgnoringLocalCacheData:
+    case URLRequest.CachePolicy.reloadIgnoringLocalCacheData,
+         URLRequest.CachePolicy.reloadIgnoringLocalAndRemoteCacheData:
         builder.cacheControl(CacheControl.FORCE_NETWORK)
-    case URLRequest.CachePolicy.reloadIgnoringLocalAndRemoteCacheData: builder.cacheControl(CacheControl.FORCE_NETWORK)
     }
 
     build(builder)


### PR DESCRIPTION
Currently, the `requestCachePolicy` of `URLSessionConfiguration` is not taken into account when performing HTTP requests since only the `cachePolicy` of the `URLRequest` itself is evaluated. This causes the session-level cache policy to be ignored whenever the request uses the default `.useProtocolCachePolicy`.

This PR introduces an effective cache policy that correctly mirrors Apple’s `URLSession` behavior:
- If the `URLRequest` specifies an explicit `cachePolicy`, it takes precedence.
- If the request uses `.useProtocolCachePolicy`, the session’s `requestCachePolicy` is applied instead.

**Example Code:**
```
import Foundation

func loadExchangeRates(currencyCode: String = "USD") {
    let urlString = "https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest" +
        "/v1/currencies/\(currencyCode.lowercased()).json"
    load(from: urlString) { result in
        switch result {
        case .success(let data):
            let jsonString = String(data: data, encoding: .utf8)!
            print(jsonString)
            
        case .failure:
            break
        }
    }
}

func load(
    from urlString: String,
    completionHandler: @escaping (Result<Data, Error>) -> Void) {
    
    if let url = URL(string: urlString) {
        let config = URLSessionConfiguration.default
        config.requestCachePolicy = .reloadIgnoringLocalCacheData
        
        let urlSession = URLSession(configuration: config)
            .dataTask(with: url) { (data, _, error) in
                if let error = error {
                    completionHandler(.failure(error))
                } else if let data = data {
                    completionHandler(.success(data))
                }
            }
        
        urlSession.resume()
    } else {
        completionHandler(.failure("Invalid URL".toError()))
    }
}

extension String {
    func toError() -> Error {
        return StringError(self)
    }
}

struct StringError: Error {
    let message: String
    init(_ message: String) {
        self.message = message
    }
}
```
---

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

