### PR TITLE
Fix Boolean handling in JSONSerialization.jsonObject(with:)

### DIFF
--- a/Sources/SkipFoundation/JSONSerialization+Parser.swift
+++ b/Sources/SkipFoundation/JSONSerialization+Parser.swift
@@ -30,6 +30,8 @@ internal class JSONParser {
                 } else {
                     throw JSONError.numberIsNotRepresentableInSwift(parsed: bd.toString())
                 }
+            case let bol as Boolean:
+                return bol == true
             case let obj as org.json.JSONObject:
                 var dict = Dictionary<String, Any>()
                 for key in obj.keys() {


### PR DESCRIPTION
previously boolean would e.g. be uploaded as Int to firestore by default

btw: tests fail for non-US locale. Formatters use Locale.current but expected values are hardcoded for en_US.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device