### PR TITLE
TimeZone initialization and validation improvements

### DIFF
--- a/Tests/SkipFoundationTests/DateTime/TestTimeZone.swift
+++ b/Tests/SkipFoundationTests/DateTime/TestTimeZone.swift
@@ -144,18 +144,14 @@ class TestTimeZone: XCTestCase {
         #if !SKIP
         XCTAssertEqual(actualName, expectedName, "expected name \"\(expectedName)\" is not equal to \"\(actualName?.description ?? "")\"")
         #endif
+        #if !SKIP
         let expectedLocalizedName = "GMT-04:00"
-
-        #if SKIP
-        throw XCTSkip("Skip TimeZone.secondsFromGMT")
-        #else
         let actualLocalizedName = tz2?.localizedName(for: .generic, locale: Locale(identifier: "en_US"))
-
         XCTAssertEqual(actualLocalizedName, expectedLocalizedName, "expected name \"\(expectedLocalizedName)\" is not equal to \"\(actualLocalizedName?.description ?? "")\"")
+        #endif
+
         let seconds2 = tz2?.secondsFromGMT() ?? 0
         XCTAssertEqual(seconds2, -14400, "GMT-0400 should be -14400 seconds but got \(seconds2) instead")
-
-        #endif
 
         let tz3 = TimeZone(identifier: "GMT-9999")
         XCTAssertNil(tz3)
@@ -168,16 +164,13 @@ class TestTimeZone: XCTestCase {
     }
 
     func test_initializingTimeZoneWithAbbreviation() {
-        #if SKIP
-        throw XCTSkip("TODO: SkipTimeZone(abbreviation:)")
-        #endif
         // Test invalid timezone abbreviation
-        var tz = TimeZone(abbreviation: "XXX")
+        let tz = TimeZone(abbreviation: "XXX")
         XCTAssertNil(tz)
         // Test valid timezone abbreviation of "AST" for "America/Halifax"
-        tz = TimeZone(abbreviation: "AST")
+        let tz2 = TimeZone(abbreviation: "AST")
         let expectedIdentifier = "America/Halifax"
-        let actualIdentifier = tz?.identifier
+        let actualIdentifier = tz2?.identifier
         XCTAssertEqual(actualIdentifier, expectedIdentifier, "expected identifier \"\(expectedIdentifier)\" is not equal to \"\(actualIdentifier?.description ?? "")\"")
     }
 


### PR DESCRIPTION
This pull request improves the robustness and correctness of the `TimeZone` implementation in `SkipFoundation`, particularly around initialization and abbreviation handling. The changes ensure that invalid identifiers and abbreviations are handled gracefully, improve compatibility with Java's timezone APIs, and expand test coverage.

**TimeZone initialization and validation improvements:**

* Updated `TimeZone.init(identifier:)` and `TimeZone.init(abbreviation:)` to detect and reject unknown or invalid identifiers and abbreviations, addressing a quirk where Java returns a default "GMT" timezone for unknown values.
* Improved `TimeZone.init(secondsFromGMT:)` to validate the seconds offset (must be within ±18 hours) and construct the correct GMT identifier string, ensuring compatibility with Swift Foundation constraints.

**Abbreviation support and mapping:**

* Populated `TimeZone.abbreviationDictionary` with a comprehensive mapping of common timezone abbreviations to their canonical identifiers, enabling correct resolution of abbreviations.
* Fixed `abbreviation(for:)` to use the correct daylight saving flag when computing the abbreviation for a given date.

**Test improvements:**

* Expanded and corrected tests in `TestTimeZone` to cover invalid abbreviations, valid abbreviation mapping, and proper handling of unknown timezones, ensuring the new logic is exercised and validated. [[1]](diffhunk://#diff-a9990831ea266c3f31f3a58d58060d739fddba7aa063e9a1d670afc2a7884141R147-L159) [[2]](diffhunk://#diff-a9990831ea266c3f31f3a58d58060d739fddba7aa063e9a1d670afc2a7884141L171-R173)Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [ ] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Generated this PR summary
Used it to fix the core issue, I experienced and then use the for to validate issue do not persists anymore. 
Added tests
-----

