### PR TITLE
Added string pluralization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,7 @@ Support levels:
 <li><code>init(data: Data, encoding: StringEncoding)</code></li>
 <li><code>init(bytes: [UInt8], encoding: StringEncoding)</code></li>
 <li><code>init(contentsOf: URL)</code></li>
+<li><code>static func localizedStringWithFormat(_ format: String, _ arguments: Any...) -> String</code></li>
 <li><code>var capitalized: String</code></li>
 <li><code>var deletingLastPathComponent: String</code></li>
 <li><code>func replacingOccurrences(of search: String, with replacement: String) -> String</code></li>

--- a/Sources/SkipFoundation/Bundle.swift
+++ b/Sources/SkipFoundation/Bundle.swift
@@ -264,10 +264,23 @@ public class Bundle : Hashable, SwiftCustomBridged {
             let table = tableName ?? "Localizable"
             var locTable = localizedTables[table]
             if locTable == nil {
-                let resURL = url(forResource: table, withExtension: "strings")
-                let resTable = resURL == nil ? nil : try? PropertyListSerialization.propertyList(from: Data(contentsOf: resURL!), format: nil)
-                locTable = Self.stringFormatsTable(from: resTable)
-                localizedTables[table] = locTable!
+                let newTable = mutableMapOf<String, Triple<String, String, MarkdownNode?>>()
+                let resTypes: [(extension: String, format: PropertyListSerialization.PropertyListFormat)] = [
+                    (extension: "strings", format: .openStep),
+                    (extension: "stringsdict", format: .xml)
+                ]
+                for resType in resTypes {
+                    if let resURL = url(forResource: table, withExtension: resType.extension),
+                       let resData = try? Data(contentsOf: resURL),
+                       let resTable = try? PropertyListSerialization.propertyList(from: resData, format: resType.format) {
+                        for (sKey, sValue) in resTable where newTable[sKey] == nil {
+                            newTable[sKey] = Triple(sValue, sValue.kotlinFormatString, MarkdownNode.from(string: sValue))
+                        }
+                    }
+                }
+
+                locTable = newTable
+                localizedTables[table] = newTable
             }
             if let formats = locTable?[key] {
                 return formats

--- a/Sources/SkipFoundation/PropertyListSerialization.swift
+++ b/Sources/SkipFoundation/PropertyListSerialization.swift
@@ -106,16 +106,14 @@ public class PropertyListSerialization {
             let categories = ["zero", "one", "two", "few", "many", "other"]
             let rules = categories.compactMap { (category: String) -> String? in
                 guard let pluralString = varDict[category] as? String else { return nil }
-                var cleaned = pluralString
-                    .replacingOccurrences(of: "%d", with: "#")
-                    .replacingOccurrences(of: "%f", with: "#")
-                    .replacingOccurrences(of: "%@", with: "{0}")
+                var cleaned = pluralString!
                 for index in 1...10 {
                     cleaned = cleaned
                         .replacingOccurrences(of: "%\(index)$@", with: "{\(index-1)}")
                         .replacingOccurrences(of: "%\(index)$d", with: "{\(index-1)}")
                 }
-                return "\(category){\(cleaned)}"
+                let icuCategory = category == "zero" ? "=0" : category
+                return "\(icuCategory){\(cleaned)}"
             }.joined(separator: " ")
 
             if !rules.isEmpty {

--- a/Sources/SkipFoundation/PropertyListSerialization.swift
+++ b/Sources/SkipFoundation/PropertyListSerialization.swift
@@ -1,24 +1,151 @@
 // Copyright 2023–2025 Skip
 // SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
 #if SKIP
+import android.util.Xml
+import org.xmlpull.v1.XmlPullParser
+import java.io.ByteArrayInputStream
 
 public class PropertyListSerialization {
+    
     @available(*, unavailable)
     public static func propertyList(_ propertyList: Any, isValidFor: PropertyListSerialization.PropertyListFormat) -> Bool {
         fatalError()
     }
 
+    public static func propertyList(from data: Data, options: PropertyListSerialization.ReadOptions = [], format: Any?) throws -> [String: String]? {
+        let text = data.utf8String
+        guard let text = text else {
+            // should this throw an error?
+            return nil
+        }
 
-    public static func propertyList(from: Data, options: PropertyListSerialization.ReadOptions = [], format: Any?) throws -> [String: String]? {
-        // TODO: auto-detect format from data content if the format argument is unset
-        return try openStepPropertyList(from: from, options: options)
+        switch format {
+        case PropertyListFormat.xml:
+            return try convertStringsDictToICUDict(from: data)
+        default:
+            // TODO: auto-detect format from data content if the format argument is unset
+            return try openStepPropertyList(from: data, options: options)
+        }
     }
 
-    static func openStepPropertyList(from: Data, options: PropertyListSerialization.ReadOptions = []) throws -> [String: String]? {
+    private static func convertStringsDictToICUDict(from data: Data) throws -> [String: String]? {
+        let parser = Xml.newPullParser()
+        parser.setInput(ByteArrayInputStream(data.platformValue), "UTF-8")
+
+        var result: [String: String] = [:]
+        var dictStack: [[String: Any]] = []
+        var keyStack: [String] = []
+        var textAccumulator = ""
+
+        var eventType = parser.getEventType()
+        while eventType != XmlPullParser.END_DOCUMENT {
+
+            let tagName = parser.getName()
+            switch eventType {
+            case XmlPullParser.START_TAG:
+                textAccumulator = ""
+                if tagName == "dict" {
+                    dictStack.append([:])
+                }
+
+            case XmlPullParser.TEXT:
+                textAccumulator += parser.getText() ?? ""
+
+            case XmlPullParser.END_TAG:
+                let content = textAccumulator.trimmingCharacters(in: .whitespacesAndNewlines)
+                switch tagName {
+                case "key":
+                    keyStack.append(content)
+                case "string":
+                    if let key = keyStack.popLast(), !dictStack.isEmpty {
+                        dictStack[dictStack.count - 1][key] = content
+                    }
+                case "dict":
+                    if let finishedDict = dictStack.popLast() {
+                        if let parentKey = keyStack.popLast(), !dictStack.isEmpty {
+                            dictStack[dictStack.count - 1][parentKey] = finishedDict
+                        } else {
+                            for (key, value) in finishedDict {
+                                /* SKIP NOWARN */
+                                if let stringsDict = value as? [String: Any],
+                                   let icuString = convertStringsDictToICUString(stringsDict) {
+                                    result[key] = icuString
+                                }
+                            }
+                        }
+                    }
+                default:
+                    break
+                }
+
+                textAccumulator = ""
+            default:
+                break
+            }
+
+            eventType = parser.next()
+        }
+
+        return result
+    }
+
+    private static func convertStringsDictToICUString(_ stringsDict: [String: Any]) -> String? {
+        guard let formatKey = stringsDict["NSStringLocalizedFormatKey"] as? String else {
+            return nil
+        }
+
+        var result: String = formatKey
+
+        /* SKIP NOWARN */
+        for (key, varDict) in stringsDict.compactMapValues({ $0 as? [String: Any] }) {
+            guard let specType = varDict["NSStringFormatSpecTypeKey"] as? String, specType == "NSStringPluralRuleType"
+            else {
+                continue
+            }
+
+            let categories = ["zero", "one", "two", "few", "many", "other"]
+            let rules = categories.compactMap { (category: String) -> String? in
+                guard let pluralString = varDict[category] as? String else { return nil }
+                var cleaned = pluralString
+                    .replacingOccurrences(of: "%d", with: "#")
+                    .replacingOccurrences(of: "%f", with: "#")
+                    .replacingOccurrences(of: "%@", with: "{0}")
+                for index in 1...10 {
+                    cleaned = cleaned
+                        .replacingOccurrences(of: "%\(index)$@", with: "{\(index-1)}")
+                        .replacingOccurrences(of: "%\(index)$d", with: "{\(index-1)}")
+                }
+                return "\(category){\(cleaned)}"
+            }.joined(separator: " ")
+
+            if !rules.isEmpty {
+                let pattern = "%#@\(key)@"
+                let replacement = "{0, plural, \(rules)}"
+
+                if result.contains(pattern) {
+                    result = result.replacingOccurrences(of: pattern, with: replacement)
+                } else if result.contains("%#@") {
+                    let parts = result.components(separatedBy: "%#@")
+                    if parts.count > 1 {
+                        let prefix = parts[0]
+                        let remaining = parts[1]
+                        let subParts = remaining.components(separatedBy: "@")
+                        if subParts.count > 1 {
+                            let suffix = subParts[1...].joined(separator: "@")
+                            result = prefix + replacement + suffix
+                        }
+                    }
+                }
+            }
+        }
+
+        return result
+    }
+
+    private static func openStepPropertyList(from data: Data, options: PropertyListSerialization.ReadOptions = []) throws -> [String: String]? {
         var dict: Dictionary<String, String> = [:]
 
-        let text = from.utf8String
-
+        let text = data.utf8String
         guard let text = text else {
             // should this throw an error?
             return nil

--- a/Sources/SkipFoundation/PropertyListSerialization.swift
+++ b/Sources/SkipFoundation/PropertyListSerialization.swift
@@ -19,11 +19,11 @@ public class PropertyListSerialization {
             return nil
         }
 
-        switch format {
-        case PropertyListFormat.xml:
+        // TODO: auto-detect format from data content if the format argument is unset
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if (format as? PropertyListFormat) == .xml || trimmed.hasPrefix("<?xml") || trimmed.hasPrefix("<plist") {
             return try convertStringsDictToICUDict(from: data)
-        default:
-            // TODO: auto-detect format from data content if the format argument is unset
+        } else {
             return try openStepPropertyList(from: data, options: options)
         }
     }

--- a/Sources/SkipFoundation/String.swift
+++ b/Sources/SkipFoundation/String.swift
@@ -15,6 +15,8 @@
 //===----------------------------------------------------------------------===//
 
 #if SKIP
+import android.icu.text.MessageFormat
+import java.util.ArrayList
 
 public typealias NSString = kotlin.String
 public func NSString(string: String) -> NSString { string }
@@ -106,6 +108,23 @@ extension String {
     @available(*, unavailable)
     public func localizedStandardCompare(_ string: String) -> ComparisonResult {
         fatalError("unsupported")
+    }
+
+    public static func localizedStringWithFormat(_ format: String, _ arguments: Any...) -> String {
+        let list = ArrayList<Any>()
+        for argument in arguments { list.add(argument) }
+        let platformArguments = list.toArray()
+
+        let locale = Locale.current.platformValue
+        if format.contains("{0, plural,") {
+            return MessageFormat(format, locale).format(platformArguments)
+        }
+
+        if !arguments.isEmpty {
+            return java.lang.String.format(locale, format, platformArguments)
+        }
+
+        return format
     }
 
     public func trimmingCharacters(in set: CharacterSet) -> String {

--- a/Tests/SkipFoundationTests/Foundation/LocaleTests.swift
+++ b/Tests/SkipFoundationTests/Foundation/LocaleTests.swift
@@ -127,6 +127,44 @@ final class LocaleTests: XCTestCase {
         ])
     }
 
+    func testLocalizableStringsDictParsing() throws {
+        let locstr = #"""
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>repeats_every_day</key>
+            <dict>
+                <key>NSStringLocalizedFormatKey</key>
+                <string>%#@num_days@</string>
+                <key>num_days</key>
+                <dict>
+                    <key>NSStringFormatSpecTypeKey</key>
+                    <string>NSStringPluralRuleType</string>
+                    <key>NSStringFormatValueTypeKey</key>
+                    <string>d</string>
+                    <key>zero</key>
+                    <string>Ne se répète jamais</string>
+                    <key>one</key>
+                    <string>Se répète quotidiennement</string>
+                    <key>other</key>
+                    <string>Se répète tous les %d jours</string>
+                </dict>
+            </dict>
+        </dict>
+        </plist>
+        """#
+
+        let data = try XCTUnwrap(locstr.data(using: .utf8))
+        let plist = try PropertyListSerialization.propertyList(from: data, options: [], format: nil)
+
+        // SKIP NOWARN
+        let dict = try XCTUnwrap(plist as? [String: Any])
+
+        XCTAssertEqual(1, dict.count)
+        XCTAssertNotNil(dict["repeats_every_day"])
+    }
+
     func testLocaleFormats() throws {
         #if !SKIP
         // TODO
@@ -803,6 +841,29 @@ final class LocaleTests: XCTestCase {
         //XCTAssertEqual("lower-case", String(localized: LocalizedStringResource("lower-case", locale: Locale(identifier: "fr"), bundle: moduleBundle)))
         // "sk" is not localized at all, so the expected behavior is to fall back to base.lproj, which is en, and so "lower-case" will be translated as "UPPER-CASE"
         XCTAssertEqual("UPPER-CASE", String(localized: LocalizedStringResource("lower-case", locale: Locale(identifier: "sk"), bundle: moduleBundle)))
+    }
+    
+    func testLocalizedPluralStringFormatting() throws {
+        #if os(macOS)
+        if !isJava && Bundle.module.url(forResource: "Localizable", withExtension: "strings", subdirectory: nil, localization: "en") == nil {
+            throw XCTSkip("Localizable.xcstrings not compiled to strings/stringsdict")
+        }
+        #endif
+
+        let bundleDesc = LocalizedStringResource.BundleDescription.atURL(Bundle.module.bundleURL)
+        var resource = LocalizedStringResource("repeats_every_day", bundle: bundleDesc)
+
+        // English
+        resource.locale = Locale(identifier: "en")
+        XCTAssertEqual(String.localizedStringWithFormat(String(localized: resource), 0), "Repeats never")
+        XCTAssertEqual(String.localizedStringWithFormat(String(localized: resource), 1), "Repeats daily")
+        XCTAssertEqual(String.localizedStringWithFormat(String(localized: resource), 5), "Repeats every 5 days")
+
+        // French
+        resource.locale = Locale(identifier: "fr")
+        XCTAssertEqual(String.localizedStringWithFormat(String(localized: resource), 0), "Ne se répète jamais")
+        XCTAssertEqual(String.localizedStringWithFormat(String(localized: resource), 1), "Se répète quotidiennement")
+        XCTAssertEqual(String.localizedStringWithFormat(String(localized: resource), 5), "Se répète tous les 5 jours")
     }
 }
 

--- a/Tests/SkipFoundationTests/Resources/Localizable.xcstrings
+++ b/Tests/SkipFoundationTests/Resources/Localizable.xcstrings
@@ -128,6 +128,239 @@
         }
       }
     },
+    "repeats_every_day" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "يتكرر كل %1$d أيام"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "يتكرر كل %1$d يوماً"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "يتكرر يومياً"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "يتكرر كل %1$d يوم"
+                }
+              },
+              "two" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "يتكرر كل يومين"
+                }
+              },
+              "zero" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "لا يتكرر أبداً"
+                }
+              }
+            }
+          }
+        },
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Repeats daily"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Repeats every %1$d days"
+                }
+              },
+              "zero" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Repeats never"
+                }
+              }
+            }
+          }
+        },
+        "fr" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Se répète quotidiennement"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Se répète tous les %1$d jours"
+                }
+              },
+              "zero" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "Ne se répète jamais"
+                }
+              }
+            }
+          }
+        },
+        "he" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "חוזר כל יום"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "חוזר כל %1$d ימים"
+                }
+              }
+            }
+          }
+        },
+        "ja" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%1$d日ごとに繰り返し"
+                }
+              }
+            }
+          }
+        },
+        "pt-BR" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Repete diariamente"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Repete a cada %1$d dias"
+                }
+              }
+            }
+          }
+        },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Повторяется каждые %1$d дня"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Повторяется каждые %1$d дней"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Повторяется каждый %1$d день"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Повторяется каждые %1$d дней"
+                }
+              }
+            }
+          }
+        },
+        "sv" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Upprepas varje dag"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Upprepas var %1$d dag"
+                }
+              }
+            }
+          }
+        },
+        "uk" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Повторюється кожні %1$d дні"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Повторюється кожні %1$d днів"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Повторюється щодня"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Повторюється кожні %1$d днів"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "每 %1$d 天重复一次"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "Settings" : {
 
     }


### PR DESCRIPTION
This PR adds string pluralization support by reading out all `.stringsdict` files in `Bundle.swift` and converting their contents into [ICU MessageFormat](https://icu.unicode.org) strings within `PropertyListSerialization.swift`. These strings are then stored in the existing `localizedTables` mapping, allowing `String.localizedStringWithFormat` to leverage the native [MessageFormat](https://developer.android.com/reference/android/icu/text/MessageFormat) on Android, which ensures that plural rules are resolved correctly according to the user's locale.

To try it out, you can check out the updated `LocalizationPlayground` in Skip Showcase.

**Related PR:**
- https://github.com/skiptools/skipapp-showcase/pull/73

**Notes & Limitations:**
- Please note that specific forms like "few" or "many" will only trigger if the device itself is set to a locale that supports them (e.g., Ukrainian). Consequently, if a string is formatted using a custom locale that requires additional grammatical forms (like in `LocalizationPlayground.swift`), these may not be correctly applied if the underlying system locale is set to a language like English, which only supports "one" and "other". However, since users typically have their devices set to their native locale, and this behavior is consistent with [Apple's documentation](https://developer.apple.com/documentation/swift/string/localizedstringwithformat(_:_:)) for localizedStringWithFormat, I believe this limitation is negligible in practice.
- Also, if you might ask why I used `localizedStringWithFormat`, it is because as far as I understood it, constructors like `String(format:locale:arguments:)` are not supported in Skip since it does not wrap Kotlin's primitive types (see [Skip Docs](https://skip.dev/docs/swiftsupport/#other-primitive-types)). Therefore, I made the decision to use the `localizedStringWithFormat` function instead to be able to archive the pluralization support.

---

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [X] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.
=> I used AI assistance while creating the ICU conversion. I manually verified the changes using Skip Showcase and my own app, and at least all of my *.stringsdict files functioned as expected on both platforms.

-----

