### PR TITLE
Delete `testThaiCalendarSymbols()` test

### DIFF
--- a/Tests/SkipFoundationTests/Foundation/DateTests.swift
+++ b/Tests/SkipFoundationTests/Foundation/DateTests.swift
@@ -197,25 +197,4 @@ final class DateTests: XCTestCase {
         XCTAssertEqual(["الأحد", "الاثنين", "الثلاثاء", "الأربعاء", "الخميس", "الجمعة", "السبت"], calendar.shortWeekdaySymbols)
         #endif
     }
-
-    func testThaiCalendarSymbols() {
-        var calendar = Calendar.current
-        calendar.locale = Locale(identifier: "th_TH")
-        #if !SKIP
-        // it seems Foundation is missing these Thai symbols
-        XCTAssertEqual("AM", calendar.amSymbol)
-        XCTAssertEqual("PM", calendar.pmSymbol)
-        #else
-        XCTAssertEqual("ก่อนเที่ยง", calendar.amSymbol)
-        XCTAssertEqual("หลังเที่ยง", calendar.pmSymbol)
-        #endif
-
-        #if !SKIP // fails on Android API 28
-        XCTAssertEqual(["ก่อน ค.ศ.", "ค.ศ."], calendar.eraSymbols)
-        XCTAssertEqual(["มกราคม", "กุมภาพันธ์", "มีนาคม", "เมษายน", "พฤษภาคม", "มิถุนายน", "กรกฎาคม", "สิงหาคม", "กันยายน", "ตุลาคม", "พฤศจิกายน", "ธันวาคม"], calendar.monthSymbols)
-        XCTAssertEqual(["ม.ค.", "ก.พ.", "มี.ค.", "เม.ย.", "พ.ค.", "มิ.ย.", "ก.ค.", "ส.ค.", "ก.ย.", "ต.ค.", "พ.ย.", "ธ.ค."], calendar.shortMonthSymbols)
-        XCTAssertEqual(["วันอาทิตย์", "วันจันทร์", "วันอังคาร", "วันพุธ", "วันพฤหัสบดี", "วันศุกร์", "วันเสาร์"], calendar.weekdaySymbols)
-        XCTAssertEqual(["อา.", "จ.", "อ.", "พ.", "พฤ.", "ศ.", "ส."], calendar.shortWeekdaySymbols)
-        #endif
-    }
 }


### PR DESCRIPTION
The expected output is highly dependent on the current device's locale data. There's no "right answer" to test against.

Fixes #106

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

