### PR TITLE
Don't use plusses in percent encoding

### DIFF
--- a/Sources/SkipFoundation/String.swift
+++ b/Sources/SkipFoundation/String.swift
@@ -132,11 +132,11 @@ extension String {
     }
 
     public func addingPercentEncoding(withAllowedCharacters allowedCharacters: CharacterSet) -> String? {
-        return UrlEncoderUtil.encode(self, allowedCharacters.platformValue, spaceToPlus: true)
+        return UrlEncoderUtil.encode(self, allowedCharacters.platformValue, spaceToPlus: false)
     }
 
     public var removingPercentEncoding: String? {
-        return UrlEncoderUtil.decode(self, plusToSpace: true)
+        return UrlEncoderUtil.decode(self, plusToSpace: false)
     }
 
     public func range(of searchString: String) -> Range<String.Index>? {

--- a/Tests/SkipFoundationTests/CoreLibs/TestString.swift
+++ b/Tests/SkipFoundationTests/CoreLibs/TestString.swift
@@ -4,6 +4,14 @@ import Foundation
 import XCTest
 
 class TestString : XCTestCase {
+    func test_percentEncodingRoundTrip() {
+        let allowed = CharacterSet.urlQueryAllowed
+        let original = "a b+c%d 中文 🎉"
+        let encoded = original.addingPercentEncoding(withAllowedCharacters: allowed)
+        XCTAssertEqual(encoded, "a%20b+c%25d%20%E4%B8%AD%E6%96%87%20%F0%9F%8E%89")
+        XCTAssertEqual(encoded?.removingPercentEncoding, original)
+    }
+
     func test_rangeof() {
         let str = "Hello, Skip!"
         let rangeAll = str.range(of: str)

--- a/Tests/SkipFoundationTests/Network/TestURLComponents.swift
+++ b/Tests/SkipFoundationTests/Network/TestURLComponents.swift
@@ -63,11 +63,7 @@ class TestURLComponents: XCTestCase {
         components?.percentEncodedQueryItems?.forEach {
             query[$0.name] = $0.value ?? ""
         }
-        #if SKIP
-        XCTAssertEqual(["feed+me": "feed+me"], query)
-        #else
         XCTAssertEqual(["feed%20me": "feed%20me"], query)
-        #endif
     }
 
     func test_string() {
@@ -266,13 +262,8 @@ class TestURLComponents: XCTestCase {
             XCTFail("first element is missing")
             return
         }
-        #if SKIP
-        XCTAssertEqual(item.name, "simple+string")
-        XCTAssertEqual(item.value, "true+is+false")
-        #else
         XCTAssertEqual(item.name, "simple%20string")
         XCTAssertEqual(item.value, "true%20is%20false")
-        #endif
     }
 
     func test_path() {


### PR DESCRIPTION
In this PR, I'm disabling `spaceToPlus` and `plusToSpace` on `UrlEncoderUtil.encode`/`decode`, to match Swift's behavior.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
    I only got this test to pass on my macOS 26.4.1 machine when I merged in #111 and #109 as well
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

