### PR TITLE
Make testThaiCalendarSymbols more flexible

### DIFF
--- a/Tests/SkipFoundationTests/Foundation/DateTests.swift
+++ b/Tests/SkipFoundationTests/Foundation/DateTests.swift
@@ -210,12 +210,29 @@ final class DateTests: XCTestCase {
         XCTAssertEqual("หลังเที่ยง", calendar.pmSymbol)
         #endif
 
-        #if !SKIP // fails on Android API 28
-        XCTAssertEqual(["ก่อน ค.ศ.", "ค.ศ."], calendar.eraSymbols)
+        // This test is highly sensitive to the locale data
+        // It varies across versions of macOS and Android
+        // So we're making a list of acceptable values; any of these are fine.
+        let thaiEraSymbols = calendar.eraSymbols
+        let acceptableThaiEraSymbols: [[String]] = [
+            ["ก่อน ค.ศ.", "ค.ศ."],
+            ["ปีก่อน ค.ศ.", "ค.ศ."],
+        ]
+        XCTAssertTrue(
+            acceptableThaiEraSymbols.contains { $0 == thaiEraSymbols },
+            "Unexpected Thai eraSymbols: \(thaiEraSymbols)"
+        )
         XCTAssertEqual(["มกราคม", "กุมภาพันธ์", "มีนาคม", "เมษายน", "พฤษภาคม", "มิถุนายน", "กรกฎาคม", "สิงหาคม", "กันยายน", "ตุลาคม", "พฤศจิกายน", "ธันวาคม"], calendar.monthSymbols)
         XCTAssertEqual(["ม.ค.", "ก.พ.", "มี.ค.", "เม.ย.", "พ.ค.", "มิ.ย.", "ก.ค.", "ส.ค.", "ก.ย.", "ต.ค.", "พ.ย.", "ธ.ค."], calendar.shortMonthSymbols)
         XCTAssertEqual(["วันอาทิตย์", "วันจันทร์", "วันอังคาร", "วันพุธ", "วันพฤหัสบดี", "วันศุกร์", "วันเสาร์"], calendar.weekdaySymbols)
-        XCTAssertEqual(["อา.", "จ.", "อ.", "พ.", "พฤ.", "ศ.", "ส."], calendar.shortWeekdaySymbols)
-        #endif
+        let thaiShortWeekdaySymbols = calendar.shortWeekdaySymbols
+        let acceptableThaiShortWeekdaySymbols: [[String]] = [
+            ["อา.", "จ.", "อ.", "พ.", "พฤ.", "ศ.", "ส."],
+            ["อาทิตย์", "จันทร์", "อังคาร", "พุธ", "พฤหัส", "ศุกร์", "เสาร์"],
+        ]
+        XCTAssertTrue(
+            acceptableThaiShortWeekdaySymbols.contains { $0 == thaiShortWeekdaySymbols },
+            "Unexpected Thai shortWeekdaySymbols: \(thaiShortWeekdaySymbols)"
+        )
     }
 }


### PR DESCRIPTION
Fixes #106

This more flexible version even passes on Android!

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

