### PR TITLE
Remove error-ish messages from these comments

### DIFF
--- a/Tests/SkipFoundationTests/Formatters/TestRelativeDateTimeFormatter.swift
+++ b/Tests/SkipFoundationTests/Formatters/TestRelativeDateTimeFormatter.swift
@@ -151,7 +151,7 @@ class TestRelativeDateTimeFormatter: XCTestCase {
         #if SKIP
         throw XCTSkip("TODO")
         #else
-        // e.g.: Test Suite 'Selected tests' started at 2025-03-01 22:20:41.197.Test Suite 'skip-foundationPackageTests.xctest' started at 2025-03-01 22:20:41.199.Test Suite 'TestRelativeDateTimeFormatter' started at 2025-03-01 22:20:41.199.Test Case '-[SkipFoundationTests.TestRelativeDateTimeFormatter test_numericSpelledOut]' started./Users/runner/work/skip-foundation/skip-foundation/Tests/SkipFoundationTests/Formatters/TestRelativeDateTimeFormatter.swift:157: error: -[SkipFoundationTests.TestRelativeDateTimeFormatter test_numericSpelledOut] : XCTAssertEqual failed: ("one year ago") is not equal to ("eleven months ago")Test Case '-[SkipFoundationTests.TestRelativeDateTimeFormatter test_numericSpelledOut]' failed (0.709 seconds).
+        // e.g.: ("one year ago") is not equal to ("eleven months ago")
         throw XCTSkip("relative date formatting assumptions break when current date is at beginnging or end of month")
         formatter.dateTimeStyle = .numeric
         formatter.unitsStyle = .spellOut
@@ -181,7 +181,7 @@ class TestRelativeDateTimeFormatter: XCTestCase {
     }
 
     func test_namedShort() throws {
-        // e.g.: [✗] Test Case '-[SkipFoundationTests.TestRelativeDateTimeFormatter test_namedShort]' started./Users/runner/work/skip-foundation/skip-foundation/Tests/SkipFoundationTests/Formatters/TestRelativeDateTimeFormatter.swift:184: error: -[SkipFoundationTests.TestRelativeDateTimeFormatter test_namedShort] : XCTAssertEqual failed: ("last yr.") is not equal to ("11 mo. ago")Test Case '-[SkipFoundationTests.TestRelativeDateTimeFormatter test_namedShort]' failed (0.695 seconds).Test Suite 'TestRelativeDateTimeFormatter' failed at 2025-03-01 22:20:41.874.
+        // e.g.: ("last yr.") is not equal to ("11 mo. ago")
         throw XCTSkip("relative date formatting assumptions break when current date is at beginnging or end of month")
         formatter.dateTimeStyle = .named
         formatter.unitsStyle = .short
@@ -218,7 +218,7 @@ class TestRelativeDateTimeFormatter: XCTestCase {
         #if SKIP
         throw XCTSkip("TODO")
         #else
-        // e.g.: Test Suite 'Selected tests' started at 2025-03-01 22:20:41.122.Test Suite 'skip-foundationPackageTests.xctest' started at 2025-03-01 22:20:41.123.Test Suite 'TestRelativeDateTimeFormatter' started at 2025-03-01 22:20:41.123.Test Case '-[SkipFoundationTests.TestRelativeDateTimeFormatter test_namedAbbreviated]' started./Users/runner/work/skip-foundation/skip-foundation/Tests/SkipFoundationTests/Formatters/TestRelativeDateTimeFormatter.swift:220: error: -[SkipFoundationTests.TestRelativeDateTimeFormatter test_namedAbbreviated] : XCTAssertEqual failed: ("last yr.") is not equal to ("11 mo. ago")Test Case '-[SkipFoundationTests.TestRelativeDateTimeFormatter test_namedAbbreviated]' failed (0.751 seconds).Test Suite 'TestRelativeDateTimeFormatter' failed at 2025-03-01 22:20:41.874.
+        // e.g.: ("last yr.") is not equal to ("11 mo. ago")
         throw XCTSkip("relative date formatting assumptions break when current date is at beginnging or end of month")
         formatter.dateTimeStyle = .named
         formatter.unitsStyle = .abbreviated

--- a/Tests/SkipFoundationTests/System/TestBundle.swift
+++ b/Tests/SkipFoundationTests/System/TestBundle.swift
@@ -389,7 +389,7 @@ class TestBundle : XCTestCase {
         XCTAssertEqual(bundle.bundleURL.path, bundle.bundlePath)
         let path = bundle.bundlePath
 
-//        // /opt/src/github/skiptools/skiphub/Tests/SkipFoundationTests/TestBundle.swift:365: error: -[SkipFoundationTests.TestBundle test_paths] : XCTAssertEqual failed: ("Optional("/opt/src/github/skiptools/skiphub/.build/arm64-apple-macosx/debug/skiphub_SkipFoundationTests.bundle/Contents/Resources")") is not equal to ("Optional("/opt/src/github/skiptools/skiphub/.build/arm64-apple-macosx/debug/skiphub_SkipFoundationTests.bundle")")
+//        // ("Optional("/opt/src/github/skiptools/skiphub/.build/arm64-apple-macosx/debug/skiphub_SkipFoundationTests.bundle/Contents/Resources")") is not equal to ("Optional("/opt/src/github/skiptools/skiphub/.build/arm64-apple-macosx/debug/skiphub_SkipFoundationTests.bundle")")
 //
 //        // etc
 //        #if os(macOS)


### PR DESCRIPTION
When we `throw XCTSkip("TODO")`, the context around the throw is logged; this makes a message appear on the console that looks like a test failure but isn't, fooling `skip test` into printing the message.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

