### PR TITLE
Fix `mailto:` URL encoding

### DIFF
--- a/Sources/SkipFoundation/CharacterSet.swift
+++ b/Sources/SkipFoundation/CharacterSet.swift
@@ -121,23 +121,20 @@ public struct CharacterSet : SetAlgebra, Hashable {
     // Also see SkipLib.Character.isNewline, .whitespacesAndNewlines
     public static let newlines: CharacterSet = CharacterSet(platformValue: toPlatformValue(["\n", "\r", "\u{000B}", "\u{000C}", "\u{0085}", "\u{2028}", "\u{2029}"]))
 
-    @available(*, unavailable)
-    public static var urlUserAllowed: CharacterSet {
-        fatalError("SKIP TODO: CharacterSet")
-    }
+    /// swift -e 'import Foundation; let s = CharacterSet.urlUserAllowed; print((0..<0..<128).compactMap { UnicodeScalar($0) }.filter { s.contains($0) }.map { String($0) }.joined())'
+    public static let urlUserAllowed = CharacterSet(platformValue: toPlatformValue(["!$&'()*+,-.0123456789;=ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~"]))
 
-    @available(*, unavailable)
-    public static var urlPasswordAllowed: CharacterSet {
-        fatalError("SKIP TODO: CharacterSet")
-    }
+    /// swift -e 'import Foundation; let s = CharacterSet.urlPasswordAllowed; print((0..<0..<128).compactMap { UnicodeScalar($0) }.filter { s.contains($0) }.map { String($0) }.joined())'
+    public static let urlPasswordAllowed = CharacterSet(platformValue: toPlatformValue(["!$&'()*+,-.0123456789;=ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~"]))
 
-    public static var urlHostAllowed: CharacterSet {
-        return urlPathAllowed
-    }
+    /// swift -e 'import Foundation; print((0..<128).compactMap(UnicodeScalar.init).filter(CharacterSet.urlHostAllowed.contains).map(String.init).joined())'
+    public static var urlHostAllowed = CharacterSet(platformValue: toPlatformValue(["!$&'()*+,-.0123456789:;=ABCDEFGHIJKLMNOPQRSTUVWXYZ[]_abcdefghijklmnopqrstuvwxyz~"]))
 
-    public static let urlPathAllowed = CharacterSet(platformValue: toPlatformValue(["-", ".", "_", "~", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"]))
+    /// swift -e 'import Foundation; print((0..<128).compactMap(UnicodeScalar.init).filter(CharacterSet.urlPathAllowed.contains).map(String.init).joined())'
+    public static let urlPathAllowed = CharacterSet(platformValue: toPlatformValue(["!$&'()*+,-./0123456789:;=@ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~"]))
 
-    public static let urlQueryAllowed = CharacterSet(platformValue: toPlatformValue(["/", "?", "&", "=", "+", "-", ".", "_", "~", "@", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"]))
+    /// swift -e 'import Foundation; print((0..<128).compactMap(UnicodeScalar.init).filter(CharacterSet.urlQueryAllowed.contains).map(String.init).joined())'
+    public static let urlQueryAllowed = CharacterSet(platformValue: toPlatformValue(["!$&'()*+,-./0123456789:;=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~"]))
 
     public static var urlFragmentAllowed: CharacterSet {
         return urlQueryAllowed

--- a/Sources/SkipFoundation/URLComponents.swift
+++ b/Sources/SkipFoundation/URLComponents.swift
@@ -167,7 +167,7 @@ public struct URLComponents : Hashable, Equatable, Sendable {
 
     public var percentEncodedQuery: String? {
         get {
-            return URLQueryItem.queryString(from: percentEncodedQueryItems)
+            return URLQueryItem.queryString(from: queryItems)
         }
         set {
             self.query = newValue?.removingPercentEncoding
@@ -262,8 +262,9 @@ public struct URLQueryItem : Hashable, Equatable, Sendable {
         }
         var query = ""
         for item in items {
-            let name = item.name
-            let value = item.value ?? ""
+            let name = item.name.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed) ?? item.name
+            let rawValue = item.value ?? ""
+            let value = rawValue.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed) ?? rawValue
             if !query.isEmpty {
                 query += "&"
             }

--- a/Tests/SkipFoundationTests/Network/TestURLComponents.swift
+++ b/Tests/SkipFoundationTests/Network/TestURLComponents.swift
@@ -66,6 +66,34 @@ class TestURLComponents: XCTestCase {
         XCTAssertEqual(["feed%20me": "feed%20me"], query)
     }
 
+    func test_mailtoBodyPreservesNewlinesAsPercentEncoding() throws {
+        let letterBody = "Dear Kate,\n\nHere's to the crazy ones.\n\nTake care,\nJohn Appleseed"
+        var components = URLComponents()
+        components.scheme = "mailto"
+        components.path = "support@example.com"
+        components.queryItems = [
+            URLQueryItem(name: "subject", value: "Diagnostics"),
+            URLQueryItem(name: "body", value: letterBody)
+        ]
+
+        // Query encoding matches Darwin once `urlQueryAllowed` includes comma, apostrophe, etc.
+        let expectedEncodedBody =
+            "Dear%20Kate,%0A%0AHere's%20to%20the%20crazy%20ones.%0A%0ATake%20care,%0AJohn%20Appleseed"
+        let percentEncodedItems = try XCTUnwrap(components.percentEncodedQueryItems)
+        let encodedBody = try XCTUnwrap(percentEncodedItems.first(where: { $0.name == "body" })?.value)
+        XCTAssertEqual(encodedBody, expectedEncodedBody)
+
+        let expectedPercentEncodedQuery = "subject=Diagnostics&body=\(expectedEncodedBody)"
+        let percentEncodedQuery = try XCTUnwrap(components.percentEncodedQuery)
+        XCTAssertEqual(percentEncodedQuery, expectedPercentEncodedQuery)
+
+        let expectedAbsolute = "mailto:support@example.com?\(expectedPercentEncodedQuery)"
+        XCTAssertEqual(components.string, expectedAbsolute)
+        let url = try XCTUnwrap(components.url)
+        let absolute = url.absoluteString
+        XCTAssertEqual(absolute, expectedAbsolute)
+    }
+
     func test_string() {
         #if SKIP
         throw XCTSkip("TODO")


### PR DESCRIPTION
1. Fixed `CharacterSet.urlHostAllowed`, `urlPathAllowed`, and `urlQueryAllowed`, all of which mismatched native Swift

2. `URLComponents.string` returned an unencoded query string, which `java.net.URI` failed to parse, forcing us into a fallback where we re-encoded the items and passed them to OkHttp, which stripped out `%0A` newlines. Now, we add percent encoding in `URLComponents.string`, so no fallback is necessary.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

* Cursor generated the `swift -e` scripts that I ran to compute the character sets (which I manually copied and pasted), 
and generated the two fixes in `URLComponents.swift`
* Cursor initially generated `test_mailtoBodyPreservesNewlinesAsPercentEncoding`, but I wound up rewriting it by hand

The test verifies the changes match Swift Foundation; I also manually tested it my (closed source) app.