### PR TITLE
Make `notice()` log at warning level

### DIFF
--- a/Sources/SkipFoundation/Logger.swift
+++ b/Sources/SkipFoundation/Logger.swift
@@ -72,7 +72,7 @@ public class SkipLogger {
 
     public func notice(_ message: LogMessage) {
         do {
-            android.util.Log.i(logName, message)
+            android.util.Log.w(logName, message)
         } catch {
             java.util.logging.Logger.getLogger(logName).log(java.util.logging.Level.CONFIG, message)
         }


### PR DESCRIPTION
In https://developer.apple.com/documentation/oslog/oslogentrylog/level-swift.enum `.notice` is the level between `.info` and `.error`.

(But, it's confusing, because `Logger.warning` actually loggs at the `.error` level in Apple `OSLog`.)

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

