### PR TITLE
Fix `URL.appendingPathComponent` for paths that require percent encoding

### DIFF
--- a/Sources/SkipFoundation/URL.swift
+++ b/Sources/SkipFoundation/URL.swift
@@ -378,7 +378,8 @@ public struct URL : Hashable, CustomStringConvertible, Codable, KotlinConverting
         if !newPath.hasSuffix("/") {
             newPath += "/"
         }
-        newPath += pathComponent
+        let encodedPathComponent = pathComponent.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlPathAllowed)!
+        newPath += encodedPathComponent
         components.percentEncodedPath = newPath
         return components.url(relativeTo: baseURL)!
     }

--- a/Tests/SkipFoundationTests/Network/TestURL.swift
+++ b/Tests/SkipFoundationTests/Network/TestURL.swift
@@ -779,14 +779,15 @@ class TestURL : XCTestCase {
     }
 
     func test_appendingPathComponent() {
-        let appendComponent = "foo"
         let urlsExpected = [
-            ("www.swift.org", "www.swift.org/\(appendComponent)"),
-            ("https://www.swift.org/", "https://www.swift.org/\(appendComponent)"),
-            ("https://www.swift.org/a+b#hash", "https://www.swift.org/a+b/\(appendComponent)#hash"),
-            ("https://www.swift.org/a%20b/#hash?q", "https://www.swift.org/a%20b/\(appendComponent)#hash?q"),
+            ("www.swift.org", "foo", "www.swift.org/foo"),
+            ("https://www.swift.org/", "foo", "https://www.swift.org/foo"),
+            ("https://www.swift.org/a+b#hash", "foo", "https://www.swift.org/a+b/foo#hash"),
+            ("https://www.swift.org/a%20b/#hash?q", "foo", "https://www.swift.org/a%20b/foo#hash?q"),
+            ("https://example.com/", "foo bar (1).png", "https://example.com/foo%20bar%20(1).png"),
+            ("https://example.com/", "foo/bar", "https://example.com/foo/bar"),
         ]
-        for (urlString, expected) in urlsExpected {
+        for (urlString, appendComponent, expected) in urlsExpected {
             let url = URL(string: urlString)!
             XCTAssertEqual(url.appendingPathComponent(appendComponent).absoluteString, expected)
         }


### PR DESCRIPTION
* Depends on #113 

On `main`, the test I added here throws a `NullPointerException`; with my fix, the test fails before merging #113, and passes after merging #113 (which fixes `CharacterSet.urlPathAllowed`)

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

