### PR TITLE
Fix Bundle.main asset path when DRM wrapper replaces applicationInfo.…

### DIFF
--- a/Sources/SkipFoundation/Bundle.swift
+++ b/Sources/SkipFoundation/Bundle.swift
@@ -32,10 +32,21 @@ public class Bundle : Hashable, SwiftCustomBridged {
         case .atURL(let url):
             self.bundleURL = url
             self.bundleIdentifier = nil
-        case .main:
-            let identifer = Self.packageName(forClassName: applicationInfo.className)
-            self.bundleIdentifier = identifer
-            self.bundleURL = Self.createBundleURL(forPackage: identifer)
+		case .main:
+			  let derivedPackage = Self.packageName(forClassName: applicationInfo.className)
+			  // Validate the derived asset path. Google Play's PairIP DRM may replace
+			  // applicationInfo.className with a DRM wrapper class, causing Bundle.main to
+			  // resolve to the wrong asset directory. If no Resources exist at the derived
+			  // path, search the asset tree for the correct bundle package.
+			  let assets = ProcessInfo.processInfo.androidContext.resources.assets
+			  let identifer: String
+			  if let contents = assets.list(derivedPackage.replace(".", "/") + "/Resources"), contents.count() > 0 {
+				  identifer = derivedPackage
+			  } else {
+				  identifer = Self.findMainBundlePackage() ?? derivedPackage
+			  }
+			  self.bundleIdentifier = identifer
+			  self.bundleURL = Self.createBundleURL(forPackage: identifer)
         case .forClass(let cls):
             let identifer = Self.packageName(forClassName: cls.java.name)
             self.bundleIdentifier = identifer
@@ -53,6 +64,24 @@ public class Bundle : Hashable, SwiftCustomBridged {
         let className = forClassName ?? "skip.foundation.Bundle"
         return className.split(separator: ".").dropLast().joined(separator: ".")
     }
+	
+	/// Search the asset tree for a package directory containing a `Resources` subdirectory.
+	/// Used as a fallback when `applicationInfo.className` has been replaced by a third-party
+	/// wrapper (e.g. Google Play's PairIP DRM), corrupting the `Bundle.main` asset path.
+	private static func findMainBundlePackage() -> String? {
+		let assets = ProcessInfo.processInfo.androidContext.resources.assets
+		guard let topLevel = assets.list(""), topLevel.count() > 0 else { return nil }
+		for top in Array(topLevel.toList()) {
+			guard let secondLevel = assets.list(top), secondLevel.count() > 0 else { continue }
+			for second in Array(secondLevel.toList()) {
+				let candidate = "\(top)/\(second)"
+				if let children = assets.list(candidate), children.contains("Resources") {
+					return candidate.replace("/", ".")
+				}
+			}
+		}
+		return nil
+	}
 
     /// Convert `showcase.module` into `asset:/showcase/module/Resources`
     private static func createBundleURL(forPackage packageName: String) -> URL {

--- a/Sources/SkipFoundation/Bundle.swift
+++ b/Sources/SkipFoundation/Bundle.swift
@@ -68,20 +68,20 @@ public class Bundle : Hashable, SwiftCustomBridged {
 	/// Search the asset tree for a package directory containing a `Resources` subdirectory.
 	/// Used as a fallback when `applicationInfo.className` has been replaced by a third-party
 	/// wrapper (e.g. Google Play's PairIP DRM), corrupting the `Bundle.main` asset path.
-	private static func findMainBundlePackage() -> String? {
-		let assets = ProcessInfo.processInfo.androidContext.resources.assets
-		guard let topLevel = assets.list(""), topLevel.count() > 0 else { return nil }
-		for top in Array(topLevel.toList()) {
-			guard let secondLevel = assets.list(top), secondLevel.count() > 0 else { continue }
-			for second in Array(secondLevel.toList()) {
-				let candidate = "\(top)/\(second)"
-				if let children = assets.list(candidate), children.contains("Resources") {
-					return candidate.replace("/", ".")
-				}
-			}
-		}
-		return nil
-	}
+	private static func findMainBundlePackage(path: String = "") -> String? {
+		  let assets = ProcessInfo.processInfo.androidContext.resources.assets
+		  guard let children = assets.list(path), children.count() > 0 else { return nil }
+		  if !path.isEmpty && children.contains("Resources") {
+			  return path.replace("/", ".")
+		  }
+		  for child in Array(children.toList()) {
+			  if child == "Resources" { continue }
+			  let childPath = path.isEmpty ? child : "\(path)/\(child)"
+			  if let found = findMainBundlePackage(path: childPath) { return found }
+		  }
+		  return nil
+	  }
+
 
     /// Convert `showcase.module` into `asset:/showcase/module/Resources`
     private static func createBundleURL(forPackage packageName: String) -> URL {


### PR DESCRIPTION
 ## Problem

  When apps are installed via Google Play, a DRM protection system called **PairIP** (`com.pairip.*`) wraps apps by replacing `applicationInfo.className` with a custom
  Application subclass (e.g. `com.pairip.application.AppController`).

  `Bundle.main` derives its asset package path from `applicationInfo.className`:

  ```swift
  case .main:
      let identifer = Self.packageName(forClassName: applicationInfo.className)
      self.bundleURL = Self.createBundleURL(forPackage: identifer)
  ```

  With PairIP active, `packageName(forClassName:)` produces `com.pairip.application` instead of the app's actual Kotlin namespace (e.g. `what.watt`), so `Bundle.main` resolves
  to `asset:/com/pairip/application/Resources` — which doesn't exist. Since `NSLocalizedString()` defaults to `Bundle.main`, **all translations fail silently** (raw keys
  returned instead of strings). The bug only manifests on Google Play installs; direct APK installs are unaffected because PairIP is not injected.

  **Why not use `androidContext.packageName`?** It returns the `applicationId` (e.g. `ch.whatwatt.app`) — the Play Store identifier — which is *not* the Kotlin namespace used
  for asset paths (e.g. `what.watt`). Apps routinely differ these two values, so `packageName` would break direct APK installs where `applicationInfo.className` is correct.

  ## Fix

  After deriving the package name as before (fast path unchanged), validate it by checking whether `assets.list(derivedPath/Resources)` returns any entries. If empty —
  indicating the derived path is wrong — search the top two levels of the asset tree for a directory containing a `Resources` subdirectory.

