### PR TITLE
Bugfix: Calendar Enumerate DST Offset Handling

### DIFF
--- a/Sources/SkipFoundation/Calendar.swift
+++ b/Sources/SkipFoundation/Calendar.swift
@@ -363,38 +363,39 @@ public struct Calendar : Hashable, Codable, CustomStringConvertible {
             return true
 
         case .hour:
-            platformCal.set(java.util.Calendar.MINUTE, 0)
-            platformCal.set(java.util.Calendar.SECOND, 0)
-            platformCal.set(java.util.Calendar.MILLISECOND, 0)
+            let originalTimeInMillis = platformCal.timeInMillis
+            let minuteMillis = platformCal.get(java.util.Calendar.MINUTE) * 60 * 1000
+            let secondMillis = platformCal.get(java.util.Calendar.SECOND) * 1000
+            let millisecond = platformCal.get(java.util.Calendar.MILLISECOND)
+            platformCal.timeInMillis = originalTimeInMillis - Int64(minuteMillis + secondMillis + millisecond)
             start = Date(platformValue: platformCal.time)
             interval = TimeInterval(60 * 60)
             return true
 
-        case .day, .dayOfYear:
+        case .day, .dayOfYear, .weekday, .weekdayOrdinal:
             clearTime(in: platformCal)
             start = Date(platformValue: platformCal.time)
-            interval = TimeInterval(24 * 60 * 60)
-            return true
-
-        case .weekday, .weekdayOrdinal:
-            clearTime(in: platformCal)
-            start = Date(platformValue: platformCal.time)
-            interval = TimeInterval(24 * 60 * 60)
+            let nextDayCal = platformCal.clone() as java.util.Calendar
+            nextDayCal.add(java.util.Calendar.DAY_OF_MONTH, 1)
+            interval = TimeInterval((nextDayCal.timeInMillis - platformCal.timeInMillis).toDouble() / 1000.0)
             return true
 
         case .month:
             platformCal.set(java.util.Calendar.DAY_OF_MONTH, 1)
             clearTime(in: platformCal)
             start = Date(platformValue: platformCal.time)
-            let numberOfDays = platformCal.getActualMaximum(java.util.Calendar.DAY_OF_MONTH)
-            interval = TimeInterval(numberOfDays) * TimeInterval(24 * 60 * 60)
+            let nextMonthCal = platformCal.clone() as java.util.Calendar
+            nextMonthCal.add(java.util.Calendar.MONTH, 1)
+            interval = TimeInterval((nextMonthCal.timeInMillis - platformCal.timeInMillis).toDouble() / 1000.0)
             return true
 
         case .weekOfMonth, .weekOfYear:
             platformCal.set(java.util.Calendar.DAY_OF_WEEK, platformCal.firstDayOfWeek)
             clearTime(in: platformCal)
             start = Date(platformValue: platformCal.time)
-            interval = TimeInterval(7 * 24 * 60 * 60)
+            let nextWeekCal = platformCal.clone() as java.util.Calendar
+            nextWeekCal.add(java.util.Calendar.WEEK_OF_YEAR, 1)
+            interval = TimeInterval((nextWeekCal.timeInMillis - platformCal.timeInMillis).toDouble() / 1000.0)
             return true
 
         case .quarter:
@@ -415,8 +416,9 @@ public struct Calendar : Hashable, Codable, CustomStringConvertible {
             platformCal.set(java.util.Calendar.DAY_OF_MONTH, 1)
             clearTime(in: platformCal)
             start = Date(platformValue: platformCal.time)
-            let numberOfDays = platformCal.getActualMaximum(java.util.Calendar.DAY_OF_YEAR)
-            interval = TimeInterval(numberOfDays) * TimeInterval(24 * 60 * 60)
+            let nextYearCal = platformCal.clone() as java.util.Calendar
+            nextYearCal.add(java.util.Calendar.YEAR, 1)
+            interval = TimeInterval((nextYearCal.timeInMillis - platformCal.timeInMillis).toDouble() / 1000.0)
             return true
 
         case .era:
@@ -661,7 +663,15 @@ public struct Calendar : Hashable, Codable, CustomStringConvertible {
                     previouslyReturnedMatchDate = matchDate
                     block(matchDate, exactMatch, &stop)
                     if stop { return }
-                    searchingDate = matchDate
+                    if components.weekOfYear != nil {
+                        if direction == .forward {
+                            searchingDate = result.newSearchDate
+                        } else {
+                            searchingDate = self.date(byAdding: .weekOfYear, value: -1, to: matchDate) ?? matchDate.addingTimeInterval(-7.0 * 24.0 * 60.0 * 60.0)
+                        }
+                    } else {
+                        searchingDate = matchDate
+                    }
                 } else if iterations < STOP_EXHAUSTIVE_SEARCH_AFTER_MAX_ITERATIONS {
                     // Try again on nil result
                     searchingDate = result.newSearchDate

--- a/Sources/SkipFoundation/Calendar_Enumerate.swift
+++ b/Sources/SkipFoundation/Calendar_Enumerate.swift
@@ -1099,8 +1099,8 @@ extension Calendar {
 
             return SearchStepResult(result: nil, newSearchDate: searchingDate)
         }
-        var matchDate = baseMatchDate
 
+        var matchDate = baseMatchDate
         if repeatedTimePolicy == .first, matchingComponents.hour != nil {
             let hasExplicitDateComponent = matchingComponents.era != nil
                 || matchingComponents.year != nil
@@ -1113,6 +1113,7 @@ extension Calendar {
                 || matchingComponents.weekdayOrdinal != nil
                 || matchingComponents.weekOfMonth != nil
                 || matchingComponents.weekOfYear != nil
+
             if direction == .forward || hasExplicitDateComponent {
                 let earlier = matchDate.addingTimeInterval(-3600.0)
                 let isAllowedByDirection: Bool
@@ -1123,6 +1124,7 @@ extension Calendar {
                 } else {
                     isAllowedByDirection = earlier < start
                 }
+
                 if isAllowedByDirection, self.date(earlier, containsMatchingComponents: matchingComponents).1 {
                     matchDate = earlier
                 }
@@ -1563,7 +1565,9 @@ extension Calendar {
                     adjusted.year = (adjusted.year ?? 0) - 1
                 }
             }
+
             return adjusted
+
         case .dayOfYear:
             var adjusted = comps
             let dateDayOfYear = self.component(.dayOfYear, from: date)
@@ -1573,7 +1577,9 @@ extension Calendar {
             } else {
                 adjusted.year = (comps.dayOfYear ?? Int.max) > dateDayOfYear ? dateYear : dateYear + 1
             }
+
             return adjusted
+
         case .weekOfYear:
             var adjusted = comps
             let dateWeekOfYear = self.component(.weekOfYear, from: date)
@@ -1583,7 +1589,9 @@ extension Calendar {
             } else {
                 adjusted.yearForWeekOfYear = (comps.weekOfYear ?? Int.max) > dateWeekOfYear ? dateYearForWeekOfYear : dateYearForWeekOfYear + 1
             }
+
             return adjusted
+
         case .day:
             var adjusted = comps
             if direction == .backward {
@@ -1617,7 +1625,9 @@ extension Calendar {
                     adjusted.year = self.component(.year, from: date)
                 }
             }
+
             return adjusted
+
         default:
             // Nothing to adjust
             return comps

--- a/Sources/SkipFoundation/Calendar_Enumerate.swift
+++ b/Sources/SkipFoundation/Calendar_Enumerate.swift
@@ -304,22 +304,14 @@ extension Calendar {
                     throw CalendarEnumerationError.dateOutOfRange(.month, result)
                 }
 
-                var duration = foundRange.duration
+                let searchDate: Date
                 if direction == .backward {
-                    let numMonth = self.component(.month, from: foundRange.start)
-                    if numMonth == 3 && (self.identifier == .gregorian || self.identifier == .buddhist || self.identifier == .japanese || self.identifier == .iso8601 || self.identifier == .republicOfChina) {
-                        // Take it back 3 days so we land in february. That is, March has 31 days, and Feb can have 28 or 29, so to ensure we get to either Feb 1 or 2, we need to take it back 3 days.
-                        duration -= 86400 * 3
-                    } else {
-                        // Take it back a day.
-                        duration -= 86400
-                    }
-
-                    // So we can go backwards in time.
-                    duration *= -1
+                    let lateLastMonth = foundRange.start.addingTimeInterval(-1)
+                    searchDate = self.dateInterval(of: .month, for: lateLastMonth)?.start ?? foundRange.start.addingTimeInterval(-86400)
+                } else {
+                    searchDate = foundRange.start.addingTimeInterval(foundRange.duration)
                 }
 
-                let searchDate = foundRange.start.addingTimeInterval(duration)
                 dateMonth = component(.month, from: searchDate)
                 result = searchDate
 
@@ -359,7 +351,8 @@ extension Calendar {
             }
 
             if direction == .backward {
-                let searchDate = foundRange.start.addingTimeInterval(-foundRange.duration)
+                let lateLastWeek = foundRange.start.addingTimeInterval(-1)
+                let searchDate = self.dateInterval(of: .weekOfYear, for: lateLastWeek)?.start ?? foundRange.start.addingTimeInterval(-foundRange.duration)
                 dateWeekOfYear = self.component(.weekOfYear, from: searchDate)
                 result = searchDate
             } else {
@@ -370,6 +363,27 @@ extension Calendar {
 
             try self.verifyAdvancingResult(result, previous: lastResult, direction: direction)
         } while weekOfYear != dateWeekOfYear
+
+        let shouldPreserveSearchTime = components.year == nil
+            && components.weekday == nil
+            && components.weekdayOrdinal == nil
+            && components.day == nil
+            && components.dayOfYear == nil
+            && components.hour == nil
+            && components.minute == nil
+            && components.second == nil
+            && components.nanosecond == nil
+        if shouldPreserveSearchTime {
+            var adjustedComponents = self.dateComponents([.yearForWeekOfYear, .weekOfYear, .weekday], from: result)
+            let time = self.dateComponents([.hour, .minute, .second], from: startingAt)
+            adjustedComponents.hour = time.hour
+            adjustedComponents.minute = time.minute
+            adjustedComponents.second = time.second
+            adjustedComponents.nanosecond = 0
+            if let adjusted = self.date(from: adjustedComponents) {
+                result = adjusted
+            }
+        }
 
         return result
     }
@@ -383,12 +397,27 @@ extension Calendar {
 
         var dateWeekOfMonth = self.component(.weekOfMonth, from: startingAt)
         guard weekOfMonth != dateWeekOfMonth else {
-            // Already matches
+            let shouldReturnWeekStart = components.year == nil
+                && components.month == nil
+                && components.weekday == nil
+                && components.weekdayOrdinal == nil
+                && components.day == nil
+                && components.hour == nil
+            if shouldReturnWeekStart,
+               let weekInterval = self.dateInterval(of: .weekOfMonth, for: startingAt) {
+                return weekInterval.start
+            }
+
             return nil
         }
 
         // After this point, result is at least startDate.
         var result = startingAt
+        if components.month != nil && direction == .backward {
+            if let foundRange = self.dateInterval(of: .month, for: result) {
+                result = foundRange.end.addingTimeInterval(-1)
+            }
+        }
         repeat {
             guard let foundRange = self.dateInterval(of: .weekOfMonth, for: result) else {
                 // Out of range
@@ -460,6 +489,14 @@ extension Calendar {
             result = tempSearchDate
         } while weekOfMonth != dateWeekOfMonth
 
+        if components.month != nil,
+           components.weekday == nil,
+           direction == .backward,
+           self.component(.weekday, from: result) == 1,
+           let adjusted = self.date(byAdding: .day, value: 1, to: result) {
+            result = adjusted
+        }
+
         return result
     }
 
@@ -491,7 +528,8 @@ extension Calendar {
             }
 
             if direction == .backward {
-                let searchDate = foundRange.start.addingTimeInterval(-foundRange.duration)
+                let lateYesterday = foundRange.start.addingTimeInterval(-1)
+                let searchDate = self.dateInterval(of: .dayOfYear, for: lateYesterday)?.start ?? foundRange.start.addingTimeInterval(-foundRange.duration)
                 dateDayOfYear = self.component(.dayOfYear, from: searchDate)
                 result = searchDate
             } else {
@@ -1052,7 +1090,7 @@ extension Calendar {
 
         // MatchDate may be nil, which indicates a need to keep iterating.
         // Step C: Validate what we found and then run block. Then prepare the search date for the next round of the loop.
-        guard let matchDate = try self._adjustedDateForMismatches(start: start, searchingDate: searchingDate, matchDate: unadjustedMatchDate, matchingComponents: matchingComponents, compsToMatch: compsToMatch, direction: direction, matchingPolicy: matchingPolicy, repeatedTimePolicy: repeatedTimePolicy, isForwardDST: &isForwardDST, isExactMatch: &exactMatch, isLeapDay: &isLeapDay) else {
+        guard let baseMatchDate = try self._adjustedDateForMismatches(start: start, searchingDate: searchingDate, matchDate: unadjustedMatchDate, matchingComponents: matchingComponents, compsToMatch: compsToMatch, direction: direction, matchingPolicy: matchingPolicy, repeatedTimePolicy: repeatedTimePolicy, isForwardDST: &isForwardDST, isExactMatch: &exactMatch, isLeapDay: &isLeapDay) else {
 
             // Try again with a bumped up date.
             if let newSearchingDate = self.bumpedDateUpToNextHigherUnitInComponents(searchingDate, matchingComponents, direction, nil) {
@@ -1060,6 +1098,35 @@ extension Calendar {
             }
 
             return SearchStepResult(result: nil, newSearchDate: searchingDate)
+        }
+        var matchDate = baseMatchDate
+
+        if repeatedTimePolicy == .first, matchingComponents.hour != nil {
+            let hasExplicitDateComponent = matchingComponents.era != nil
+                || matchingComponents.year != nil
+                || matchingComponents.yearForWeekOfYear != nil
+                || matchingComponents.dayOfYear != nil
+                || matchingComponents.quarter != nil
+                || matchingComponents.month != nil
+                || matchingComponents.day != nil
+                || matchingComponents.weekday != nil
+                || matchingComponents.weekdayOrdinal != nil
+                || matchingComponents.weekOfMonth != nil
+                || matchingComponents.weekOfYear != nil
+            if direction == .forward || hasExplicitDateComponent {
+                let earlier = matchDate.addingTimeInterval(-3600.0)
+                let isAllowedByDirection: Bool
+                if direction == .forward {
+                    isAllowedByDirection = earlier > start
+                } else if let previouslyReturnedMatchDate {
+                    isAllowedByDirection = earlier < previouslyReturnedMatchDate
+                } else {
+                    isAllowedByDirection = earlier < start
+                }
+                if isAllowedByDirection, self.date(earlier, containsMatchingComponents: matchingComponents).1 {
+                    matchDate = earlier
+                }
+            }
         }
 
         // Check the components to see if they match what was desired.
@@ -1497,14 +1564,36 @@ extension Calendar {
                 }
             }
             return adjusted
+        case .dayOfYear:
+            var adjusted = comps
+            let dateDayOfYear = self.component(.dayOfYear, from: date)
+            let dateYear = self.component(.year, from: date)
+            if direction == .backward {
+                adjusted.year = (comps.dayOfYear ?? Int.max) >= dateDayOfYear ? dateYear - 1 : dateYear
+            } else {
+                adjusted.year = (comps.dayOfYear ?? Int.max) > dateDayOfYear ? dateYear : dateYear + 1
+            }
+            return adjusted
+        case .weekOfYear:
+            var adjusted = comps
+            let dateWeekOfYear = self.component(.weekOfYear, from: date)
+            let dateYearForWeekOfYear = self.component(.yearForWeekOfYear, from: date)
+            if direction == .backward {
+                adjusted.yearForWeekOfYear = (comps.weekOfYear ?? Int.max) >= dateWeekOfYear ? dateYearForWeekOfYear - 1 : dateYearForWeekOfYear
+            } else {
+                adjusted.yearForWeekOfYear = (comps.weekOfYear ?? Int.max) > dateWeekOfYear ? dateYearForWeekOfYear : dateYearForWeekOfYear + 1
+            }
+            return adjusted
         case .day:
             var adjusted = comps
             if direction == .backward {
                 let dateDay = self.component(.day, from: date)
                 // We need to make sure we don't surpass the day we want.
                 if comps.day ?? Int.max >= dateDay {
-                    let tempDate = self.date(byAdding: .month, value: -1, to: date)!
-                    adjusted.month = self.component(.month, from: tempDate)
+                    let dateMonth = self.component(.month, from: date)
+                    let dateYear = self.component(.year, from: date)
+                    adjusted.month = dateMonth == 1 ? 12 : dateMonth - 1
+                    adjusted.year = dateMonth == 1 ? dateYear - 1 : dateYear
                 } else {
                     // Adjusted is the date components we're trying to match against; dateDay is the current day of the current search date.
                     // See the comment in enumerateDates for the justification for adding the month to the components here.
@@ -1519,11 +1608,13 @@ extension Calendar {
                     // These same changes apply to the backwards case above.
                     let dateMonth = self.component(.month, from: date)
                     adjusted.month = dateMonth
+                    adjusted.year = self.component(.year, from: date)
                 }
             } else {
                 let dateDay = self.component(.day, from: date)
                 if comps.day ?? Int.max > dateDay {
                     adjusted.month = self.component(.month, from: date)
+                    adjusted.year = self.component(.year, from: date)
                 }
             }
             return adjusted
@@ -1801,6 +1892,7 @@ private extension DateComponents {
         if self.weekOfMonth != other.weekOfMonth { mismatched.insert(.weekOfMonth) }
         if self.weekOfYear != other.weekOfYear { mismatched.insert(.weekOfYear) }
         if self.yearForWeekOfYear != other.yearForWeekOfYear { mismatched.insert(.yearForWeekOfYear) }
+        if self.dayOfYear != other.dayOfYear { mismatched.insert(.dayOfYear) }
         if self.nanosecond != other.nanosecond { mismatched.insert(.nanosecond) }
         return mismatched
     }

--- a/Sources/SkipFoundation/Calendar_Enumerate.swift
+++ b/Sources/SkipFoundation/Calendar_Enumerate.swift
@@ -418,6 +418,7 @@ extension Calendar {
                 result = foundRange.end.addingTimeInterval(-1)
             }
         }
+
         repeat {
             guard let foundRange = self.dateInterval(of: .weekOfMonth, for: result) else {
                 // Out of range

--- a/Tests/SkipFoundationTests/DateTime/TestCalendarEnumerate.swift
+++ b/Tests/SkipFoundationTests/DateTime/TestCalendarEnumerate.swift
@@ -413,6 +413,60 @@ final class TestCalendarEnumerate: XCTestCase {
         XCTAssertTrue(results.isEmpty)
     }
 
+    func testEnumerateDates_years_forward_dstOffset_shouldReturnExpectedResult() {
+        // Arrange
+        self.sut.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let start = ISO8601DateFormatter().date(from: "2025-07-01T00:00:00Z")!
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 1
+        components.day = 1
+        components.hour = 2
+        components.minute = 0
+        components.second = 0
+
+        // Act
+        var results: [Date] = []
+        self.sut.enumerateDates(startingAfter: start, matching: components, matchingPolicy: .strict, direction: .forward) { (date, _, stop) in
+            if let date = date {
+                results.append(date)
+                stop = true
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].ISO8601Format(), "2026-01-01T01:00:00Z")
+    }
+
+    func testEnumerateDates_years_backward_dstOffset_shouldReturnExpectedResult() {
+        // Arrange
+        self.sut.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let start = ISO8601DateFormatter().date(from: "2026-12-01T00:00:00Z")!
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 1
+        components.day = 1
+        components.hour = 2
+        components.minute = 0
+        components.second = 0
+
+        // Act
+        var results: [Date] = []
+        self.sut.enumerateDates(startingAfter: start, matching: components, matchingPolicy: .strict, direction: .backward) { (date, _, stop) in
+            if let date = date {
+                results.append(date)
+                stop = true
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].ISO8601Format(), "2026-01-01T01:00:00Z")
+    }
+
     // MARK: - Enumerate Dates (Quarter) Tests
     func testEnumerateDates_quarter_forward_validComponents_shouldReturnExpectedResult() {
         // Arrange
@@ -494,6 +548,64 @@ final class TestCalendarEnumerate: XCTestCase {
 
         // Assert
         XCTAssertTrue(results.isEmpty)
+    }
+
+    func testEnumerateDates_quarter_forward_dstOffset_shouldReturnExpectedResult() {
+        // Arrange
+        self.sut.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let start = ISO8601DateFormatter().date(from: "2025-07-01T00:00:00Z")!
+        var components = DateComponents()
+        components.quarter = 4
+        components.weekday = 3
+        components.hour = 2
+        components.minute = 0
+        components.second = 0
+
+        // Act
+        var results: [Date] = []
+        var iterations = 0
+        self.sut.enumerateDates(startingAfter: start, matching: components, matchingPolicy: .strict, direction: .forward) { (date, _, stop) in
+            if let date = date {
+                results.append(date)
+            }
+            iterations += 1
+            if iterations >= 2 {
+                stop = true
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0].ISO8601Format(), "2025-10-07T00:00:00Z")
+        XCTAssertEqual(results[1].ISO8601Format(), "2026-10-06T00:00:00Z")
+    }
+
+    func testEnumerateDates_quarter_backward_dstOffset_shouldReturnExpectedResult() {
+        // Arrange
+        self.sut.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let start = ISO8601DateFormatter().date(from: "2025-12-01T00:00:00Z")!
+        var components = DateComponents()
+        components.quarter = 4
+
+        // Act
+        var results: [Date] = []
+        var iterations = 0
+        self.sut.enumerateDates(startingAfter: start, matching: components, matchingPolicy: .strict, direction: .backward) { (date, _, stop) in
+            if let date = date {
+                results.append(date)
+            }
+            iterations += 1
+            if iterations >= 2 {
+                stop = true
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0].ISO8601Format(), "2024-12-31T22:59:59Z")
+        XCTAssertEqual(results[1].ISO8601Format(), "2023-12-31T22:59:59Z")
     }
 
     // MARK: - Enumerate Dates (Month) Tests
@@ -580,6 +692,68 @@ final class TestCalendarEnumerate: XCTestCase {
         XCTAssertTrue(results.isEmpty)
     }
 
+    func testEnumerateDates_month_forward_dstOffset_shouldReturnExpectedResult() {
+        // Arrange
+        self.sut.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let start = ISO8601DateFormatter().date(from: "2025-09-01T00:00:00Z")!
+        var components = DateComponents()
+        components.month = 11
+        components.day = 1
+        components.hour = 2
+        components.minute = 0
+        components.second = 0
+
+        // Act
+        var results: [Date] = []
+        var iterations = 0
+        self.sut.enumerateDates(startingAfter: start, matching: components, matchingPolicy: .strict, direction: .forward) { (date, _, stop) in
+            if let date = date {
+                results.append(date)
+            }
+            iterations += 1
+            if iterations >= 2 {
+                stop = true
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0].ISO8601Format(), "2025-11-01T01:00:00Z")
+        XCTAssertEqual(results[1].ISO8601Format(), "2026-11-01T01:00:00Z")
+    }
+
+    func testEnumerateDates_month_backward_dstOffset_shouldReturnExpectedResult() {
+        // Arrange
+        self.sut.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let start = ISO8601DateFormatter().date(from: "2025-12-01T00:00:00Z")!
+        var components = DateComponents()
+        components.month = 11
+        components.day = 1
+        components.hour = 2
+        components.minute = 0
+        components.second = 0
+
+        // Act
+        var results: [Date] = []
+        var iterations = 0
+        self.sut.enumerateDates(startingAfter: start, matching: components, matchingPolicy: .strict, direction: .backward) { (date, _, stop) in
+            if let date = date {
+                results.append(date)
+            }
+            iterations += 1
+            if iterations >= 2 {
+                stop = true
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0].ISO8601Format(), "2025-11-01T01:00:00Z")
+        XCTAssertEqual(results[1].ISO8601Format(), "2024-11-01T01:00:00Z")
+    }
+
     // MARK: - Enumerate Dates (Week of Year) Tests
     func testEnumerateDates_weekOfYear_forward_validComponents_shouldReturnExpectedResult() {
         // Arrange
@@ -661,6 +835,64 @@ final class TestCalendarEnumerate: XCTestCase {
 
         // Assert
         XCTAssertTrue(results.isEmpty)
+    }
+
+    func testEnumerateDates_weekOfYear_forward_dstOffset_shouldReturnExpectedResult() {
+        // Arrange
+        self.sut.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let start = ISO8601DateFormatter().date(from: "2025-07-01T00:00:00Z")!
+        var components = DateComponents()
+        components.weekOfYear = 44
+        components.weekday = 3
+        components.hour = 2
+        components.minute = 0
+        components.second = 0
+
+        // Act
+        var results: [Date] = []
+        var iterations = 0
+        self.sut.enumerateDates(startingAfter: start, matching: components, matchingPolicy: .strict, direction: .forward) { (date, _, stop) in
+            if let date = date {
+                results.append(date)
+            }
+            iterations += 1
+            if iterations >= 2 {
+                stop = true
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0].ISO8601Format(), "2025-10-28T01:00:00Z")
+        XCTAssertEqual(results[1].ISO8601Format(), "2026-10-27T01:00:00Z")
+    }
+
+    func testEnumerateDates_weekOfYear_backward_dstOffset_shouldReturnExpectedResult() {
+        // Arrange
+        self.sut.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let start = ISO8601DateFormatter().date(from: "2025-12-01T00:00:00Z")!
+        var components = DateComponents()
+        components.weekOfYear = 44
+
+        // Act
+        var results: [Date] = []
+        var iterations = 0
+        self.sut.enumerateDates(startingAfter: start, matching: components, matchingPolicy: .strict, direction: .backward) { (date, _, stop) in
+            if let date = date {
+                results.append(date)
+            }
+            iterations += 1
+            if iterations >= 2 {
+                stop = true
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0].ISO8601Format(), "2025-10-25T23:00:00Z")
+        XCTAssertEqual(results[1].ISO8601Format(), "2024-10-26T23:00:00Z")
     }
 
     // MARK: - Enumerate Dates (Week of Month) Tests
@@ -749,6 +981,66 @@ final class TestCalendarEnumerate: XCTestCase {
 
         // Assert
         XCTAssertTrue(results.isEmpty)
+    }
+
+    func testEnumerateDates_weekOfMonth_forward_dstOffset_shouldReturnExpectedResult() {
+        // Arrange
+        self.sut.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let start = ISO8601DateFormatter().date(from: "2025-10-01T00:00:00Z")!
+        var components = DateComponents()
+        components.weekOfMonth = 5
+        components.weekday = 3
+        components.hour = 2
+        components.minute = 0
+        components.second = 0
+
+        // Act
+        var results: [Date] = []
+        var iterations = 0
+        self.sut.enumerateDates(startingAfter: start, matching: components, matchingPolicy: .strict, direction: .forward) { (date, _, stop) in
+            if let date = date {
+                results.append(date)
+            }
+            iterations += 1
+            if iterations >= 2 {
+                stop = true
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0].ISO8601Format(), "2025-10-28T01:00:00Z")
+        XCTAssertEqual(results[1].ISO8601Format(), "2025-11-25T01:00:00Z")
+    }
+
+    func testEnumerateDates_weekOfMonth_backward_dstOffset_shouldReturnExpectedResult() {
+        // Arrange
+        self.sut.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let start = ISO8601DateFormatter().date(from: "2025-12-01T00:00:00Z")!
+        var components = DateComponents()
+        components.weekOfMonth = 5
+
+        // Act
+        var results: [Date] = []
+        var iterations = 0
+        self.sut.enumerateDates(startingAfter: start, matching: components, matchingPolicy: .strict, direction: .backward) { (date, _, stop) in
+            if let date = date {
+                results.append(date)
+            }
+            iterations += 1
+            if iterations >= 4 {
+                stop = true
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(results.count, 4)
+        XCTAssertEqual(results[0].ISO8601Format(), "2025-11-22T23:00:00Z")
+        XCTAssertEqual(results[1].ISO8601Format(), "2025-10-25T22:00:00Z")
+        XCTAssertEqual(results[2].ISO8601Format(), "2025-09-27T22:00:00Z")
+        XCTAssertEqual(results[3].ISO8601Format(), "2025-08-23T22:00:00Z")
     }
 
     // MARK: - Enumerate Dates (Day of Year) Tests
@@ -922,6 +1214,68 @@ final class TestCalendarEnumerate: XCTestCase {
 
         // Assert
         XCTAssertTrue(results.isEmpty)
+    }
+
+    @available(macOS 15, iOS 18, *)
+    func testEnumerateDates_dayOfYear_forward_dstOffset_shouldReturnExpectedResult() {
+        // Arrange
+        self.sut.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let start = ISO8601DateFormatter().date(from: "2025-07-01T00:00:00Z")!
+        var components = DateComponents()
+        components.dayOfYear = 301
+        components.hour = 2
+        components.minute = 0
+        components.second = 0
+
+        // Act
+        var results: [Date] = []
+        var iterations = 0
+        self.sut.enumerateDates(startingAfter: start, matching: components, matchingPolicy: .strict, direction: .forward) { (date, _, stop) in
+            if let date = date {
+                results.append(date)
+            }
+            iterations += 1
+            if iterations >= 2 {
+                stop = true
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0].ISO8601Format(), "2025-10-28T01:00:00Z")
+        XCTAssertEqual(results[1].ISO8601Format(), "2026-10-28T01:00:00Z")
+    }
+
+    @available(macOS 15, iOS 18, *)
+    func testEnumerateDates_dayOfYear_backward_dstOffset_shouldReturnExpectedResult() {
+        // Arrange
+        self.sut.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let start = ISO8601DateFormatter().date(from: "2025-12-01T00:00:00Z")!
+        var components = DateComponents()
+        components.dayOfYear = 301
+        components.hour = 2
+        components.minute = 0
+        components.second = 0
+
+        // Act
+        var results: [Date] = []
+        var iterations = 0
+        self.sut.enumerateDates(startingAfter: start, matching: components, matchingPolicy: .strict, direction: .backward) { (date, _, stop) in
+            if let date = date {
+                results.append(date)
+            }
+            iterations += 1
+            if iterations >= 2 {
+                stop = true
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0].ISO8601Format(), "2025-10-28T01:00:00Z")
+        XCTAssertEqual(results[1].ISO8601Format(), "2024-10-27T00:00:00Z")
     }
 
     // MARK: - Enumerate Dates (Day) Tests
@@ -1098,6 +1452,66 @@ final class TestCalendarEnumerate: XCTestCase {
         XCTAssertTrue(results.isEmpty)
     }
 
+    func testEnumerateDates_day_forward_dstOffset_shouldReturnExpectedResult() {
+        // Arrange
+        self.sut.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let start = ISO8601DateFormatter().date(from: "2025-10-24T00:00:00Z")!
+        var components = DateComponents()
+        components.day = 27
+        components.hour = 2
+        components.minute = 0
+        components.second = 0
+
+        // Act
+        var results: [Date] = []
+        var iterations = 0
+        self.sut.enumerateDates(startingAfter: start, matching: components, matchingPolicy: .strict, direction: .forward) { (date, _, stop) in
+            if let date = date {
+                results.append(date)
+            }
+            iterations += 1
+            if iterations >= 2 {
+                stop = true
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0].ISO8601Format(), "2025-10-27T01:00:00Z")
+        XCTAssertEqual(results[1].ISO8601Format(), "2025-11-27T01:00:00Z")
+    }
+
+    func testEnumerateDates_day_backward_dstOffset_shouldReturnExpectedResult() {
+        // Arrange
+        self.sut.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let start = ISO8601DateFormatter().date(from: "2025-10-30T00:00:00Z")!
+        var components = DateComponents()
+        components.day = 27
+        components.hour = 2
+        components.minute = 0
+        components.second = 0
+
+        // Act
+        var results: [Date] = []
+        var iterations = 0
+        self.sut.enumerateDates(startingAfter: start, matching: components, matchingPolicy: .strict, direction: .backward) { (date, _, stop) in
+            if let date = date {
+                results.append(date)
+            }
+            iterations += 1
+            if iterations >= 2 {
+                stop = true
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0].ISO8601Format(), "2025-10-27T01:00:00Z")
+        XCTAssertEqual(results[1].ISO8601Format(), "2025-09-27T00:00:00Z")
+    }
+
     // MARK: - Enumerate Dates (Weekday) Tests
     func testEnumerateDates_weekday_forward_validComponents_shouldReturnExpectedResult() {
         // Arrange
@@ -1183,6 +1597,70 @@ final class TestCalendarEnumerate: XCTestCase {
 
         // Assert
         XCTAssertTrue(results.isEmpty)
+    }
+
+    func testEnumerateDates_weekday_forward_dstOffset_shouldReturnExpectedResult() {
+        // Arrange
+        self.sut.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let start = ISO8601DateFormatter().date(from: "2025-07-01T00:00:00Z")!
+        var components = DateComponents()
+        components.weekday = 3
+        components.hour = 2
+        components.minute = 0
+        components.second = 0
+
+        // Act
+        var results: [Date] = []
+        var iterations = 0
+        self.sut.enumerateDates(startingAfter: start, matching: components, matchingPolicy: .strict, direction: .forward) { (date, _, stop) in
+            if let date = date {
+                results.append(date)
+            }
+            iterations += 1
+            if iterations >= 18 {
+                stop = true
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(results.count, 18)
+        XCTAssertEqual(results[0].ISO8601Format(), "2025-07-08T00:00:00Z")
+        XCTAssertEqual(results[15].ISO8601Format(), "2025-10-21T00:00:00Z")
+        XCTAssertEqual(results[16].ISO8601Format(), "2025-10-28T01:00:00Z")
+        XCTAssertEqual(results[17].ISO8601Format(), "2025-11-04T01:00:00Z")
+    }
+
+    func testEnumerateDates_weekday_backward_dstOffset_shouldReturnExpectedResult() {
+        // Arrange
+        self.sut.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let start = ISO8601DateFormatter().date(from: "2025-12-01T00:00:00Z")!
+        var components = DateComponents()
+        components.weekday = 3
+        components.hour = 2
+        components.minute = 0
+        components.second = 0
+
+        // Act
+        var results: [Date] = []
+        var iterations = 0
+        self.sut.enumerateDates(startingAfter: start, matching: components, matchingPolicy: .strict, direction: .backward) { (date, _, stop) in
+            if let date = date {
+                results.append(date)
+            }
+            iterations += 1
+            if iterations >= 6 {
+                stop = true
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(results.count, 6)
+        XCTAssertEqual(results[0].ISO8601Format(), "2025-11-25T01:00:00Z")
+        XCTAssertEqual(results[3].ISO8601Format(), "2025-11-04T01:00:00Z")
+        XCTAssertEqual(results[4].ISO8601Format(), "2025-10-28T01:00:00Z")
+        XCTAssertEqual(results[5].ISO8601Format(), "2025-10-21T00:00:00Z")
     }
 
     // MARK: - Enumerate Dates (Weekday Ordinal) Tests
@@ -1274,6 +1752,67 @@ final class TestCalendarEnumerate: XCTestCase {
 
         // Assert
         XCTAssertTrue(results.isEmpty)
+    }
+
+    func testEnumerateDates_weekdayOrdinal_forward_dstOffset_shouldReturnExpectedResult() {
+        // Arrange
+        self.sut.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let start = ISO8601DateFormatter().date(from: "2025-09-01T00:00:00Z")!
+        var components = DateComponents()
+        components.weekday = 3
+        components.weekdayOrdinal = 4
+        components.hour = 2
+        components.minute = 0
+        components.second = 0
+
+        // Act
+        var results: [Date] = []
+        var iterations = 0
+        self.sut.enumerateDates(startingAfter: start, matching: components, matchingPolicy: .strict, direction: .forward) { (date, _, stop) in
+            if let date = date {
+                results.append(date)
+            }
+            iterations += 1
+            if iterations >= 3 {
+                stop = true
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(results.count, 3)
+        XCTAssertEqual(results[0].ISO8601Format(), "2025-09-23T00:00:00Z")
+        XCTAssertEqual(results[1].ISO8601Format(), "2025-10-28T01:00:00Z")
+        XCTAssertEqual(results[2].ISO8601Format(), "2025-11-25T01:00:00Z")
+    }
+
+    func testEnumerateDates_weekdayOrdinal_backward_dstOffset_shouldReturnExpectedResult() {
+        // Arrange
+        self.sut.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let start = ISO8601DateFormatter().date(from: "2025-12-01T00:00:00Z")!
+        var components = DateComponents()
+        components.weekdayOrdinal = 4
+
+        // Act
+        var results: [Date] = []
+        var iterations = 0
+        self.sut.enumerateDates(startingAfter: start, matching: components, matchingPolicy: .strict, direction: .backward) { (date, _, stop) in
+            if let date = date {
+                results.append(date)
+            }
+            iterations += 1
+            if iterations >= 4 {
+                stop = true
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(results.count, 4)
+        XCTAssertEqual(results[0].ISO8601Format(), "2025-11-27T23:00:00Z")
+        XCTAssertEqual(results[1].ISO8601Format(), "2025-10-27T23:00:00Z")
+        XCTAssertEqual(results[2].ISO8601Format(), "2025-09-27T22:00:00Z")
+        XCTAssertEqual(results[3].ISO8601Format(), "2025-08-27T22:00:00Z")
     }
 
     // MARK: - Enumerate Dates (Time) Tests
@@ -1453,6 +1992,66 @@ final class TestCalendarEnumerate: XCTestCase {
 
         // Assert
         XCTAssertTrue(results.isEmpty)
+    }
+
+    func testEnumerateDates_time_forward_dstOffset_shouldReturnExpectedResult() {
+        // Arrange
+        self.sut.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let start = ISO8601DateFormatter().date(from: "2025-10-25T20:30:00Z")!
+        var components = DateComponents()
+        components.hour = 2
+        components.minute = 30
+        components.second = 0
+
+        // Act
+        var results: [Date] = []
+        var iterations = 0
+        self.sut.enumerateDates(startingAfter: start, matching: components, matchingPolicy: .strict, direction: .forward) { (date, _, stop) in
+            if let date = date {
+                results.append(date)
+            }
+            iterations += 1
+            if iterations >= 3 {
+                stop = true
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(results.count, 3)
+        XCTAssertEqual(results[0].ISO8601Format(), "2025-10-26T00:30:00Z")
+        XCTAssertEqual(results[1].ISO8601Format(), "2025-10-27T01:30:00Z")
+        XCTAssertEqual(results[2].ISO8601Format(), "2025-10-28T01:30:00Z")
+    }
+
+    func testEnumerateDates_time_backward_dstOffset_shouldReturnExpectedResult() {
+        // Arrange
+        self.sut.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let start = ISO8601DateFormatter().date(from: "2025-10-26T06:00:00Z")!
+        var components = DateComponents()
+        components.hour = 2
+        components.minute = 30
+        components.second = 0
+
+        // Act
+        var results: [Date] = []
+        var iterations = 0
+        self.sut.enumerateDates(startingAfter: start, matching: components, matchingPolicy: .strict, direction: .backward) { (date, _, stop) in
+            if let date = date {
+                results.append(date)
+            }
+            iterations += 1
+            if iterations >= 3 {
+                stop = true
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(results.count, 3)
+        XCTAssertEqual(results[0].ISO8601Format(), "2025-10-26T01:30:00Z")
+        XCTAssertEqual(results[1].ISO8601Format(), "2025-10-25T00:30:00Z")
+        XCTAssertEqual(results[2].ISO8601Format(), "2025-10-24T00:30:00Z")
     }
 
     // MARK: - Special Tests


### PR DESCRIPTION
While using Calendar.enumerateDates, I noticed that date enumeration could produce incorrect results around Daylight Saving Time (DST) transitions in some cases.

This PR fixes the enumeration logic so that each generated date is evaluated with the correct time zone offset for that specific instant, preventing skipped or shifted results across DST transitions.


---

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [X] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Codex was used to investigate and implement the fix for the DST-related calendar enumeration issue. After reviewing the proposed changes, I tested the fix by extending the unit tests in Skip Foundation, as well as by running the existing ones. Additionally, I ran the unit tests of my Skip Light variant of the [custom repeat date library](https://github.com/pixyzeh/custom-repeat-date) as well as the unit tests of my own app where the bug initially occurred.

-----

