### PR TITLE
Bugfix: Use Locale.ROOT for ISO8601 date formatting to prevent localized digits

### DIFF
--- a/Sources/SkipFoundation/Date.swift
+++ b/Sources/SkipFoundation/Date.swift
@@ -181,9 +181,7 @@ public struct Date : Hashable, CustomStringConvertible, Comparable, Codable, Kot
 
     public func ISO8601Format(_ style: Date.ISO8601FormatStyle = .iso8601) -> String {
         // TODO: use the style parameters
-        // local time zone specific
-        // return java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", java.util.Locale.getDefault()).format(platformValue)
-        var dateFormat = java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", java.util.Locale.getDefault())
+        var dateFormat = java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", java.util.Locale.ROOT)
         dateFormat.timeZone = java.util.TimeZone.getTimeZone("GMT")
         return dateFormat.format(platformValue)
     }

--- a/Tests/SkipFoundationTests/Foundation/DateTests.swift
+++ b/Tests/SkipFoundationTests/Foundation/DateTests.swift
@@ -49,6 +49,26 @@ final class DateTests: XCTestCase {
         XCTAssertEqual("4001-01-01T00:00:00Z", Date.distantFuture.ISO8601Format())
     }
 
+    func testISO8601FormattingIsLocaleIndependent() throws {
+        let date = Date(timeIntervalSince1970: 1_783_042_560)
+
+        #if SKIP
+        // Simulates a device configured with Eastern Arabic numerals (0-9 -> ٠-٩).
+        // This replicates the OS-level system settings that would distort technical
+        // string formatting when relying on `Locale.getDefault()`.
+        let originalLocale = java.util.Locale.getDefault()
+        let arabicNumbersLocale = java.util.Locale.Builder()
+            .setLanguage("ar")
+            .setExtension(java.util.Locale.UNICODE_LOCALE_EXTENSION, "nu-arab")
+            .build()
+
+        java.util.Locale.setDefault(arabicNumbersLocale)
+        defer { java.util.Locale.setDefault(originalLocale) }
+        #endif
+
+        XCTAssertEqual("2026-07-03T01:36:00Z", date.ISO8601Format())
+    }
+
     func testDateFormatting() throws {
         func fmt(_ format: String, _ date: Date) -> String {
             let fmt = DateFormatter()


### PR DESCRIPTION
This PR fixes a bug where `Date.ISO8601Format()` would produce localized ISO 8601 strings depending on the user's Android device locale instead of a stable, locale-independent representation.

The root of the issue was that the previous implementation used Java's default locale (`java.util.Locale.getDefault()`). On devices set to languages like Arabic or Hindi, however, `SimpleDateFormat` automatically localized the output:

* It converted numbers to non-ASCII digits (e.g., `٢٠٢٦` instead of `2026`)
* It shifted years based on alternative calendars

Example:

**iOS:**
<img width="400" alt="iOS (AR)" src="https://github.com/user-attachments/assets/5c7eb871-84c9-4272-bec6-d2c7cf0f046d" />

**Android:**
<img width="400" alt="Android (AR)" src="https://github.com/user-attachments/assets/1ba7724b-41d3-4db5-9126-935d7c17c48b" />

> As you can see here, the digits of the date string were converted to Eastern Arabic numerals before the bugfix, whereas on iOS the ISO 8601 representation remained the same in every locale.

Since I use these date strings as timestamps in SkipSQL, this localization broke my database layer and caused record deserialization to fail as soon as the system language was changed.

To fix the issue, I replaced `java.util.Locale.getDefault()` with `java.util.Locale.ROOT`. Similar to Swift's `en_US_POSIX`, it avoids locale-specific number systems and ensures the output uses standard ASCII digits (0–9), making the ISO 8601 representation consistent across Android and iOS regardless of the user's device locale.


---

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

