### PR TITLE
Harden JSONEncoder.wrapEncodable + dictionary encoding regression test (skip-foundation#62)

### DIFF
--- a/Sources/SkipFoundation/JSONEncoder.swift
+++ b/Sources/SkipFoundation/JSONEncoder.swift
@@ -387,7 +387,10 @@ extension _SpecialTreatmentEncoder {
             return .number(decimal.toPlainString())
         default:
             let encoder = self.getEncoder(for: additionalKey)
-            // SKIP REPLACE: (encodable as Encodable).encode(encoder)
+            // On SKIP the generic bound is weakened to `E: Any` (see the SKIP DECLARE above), so this
+            // is an unchecked downcast. Fail with an actionable EncodingError naming the offending
+            // type instead of a bare ClassCastException if a non-Encodable value ever reaches here.
+            // SKIP REPLACE: (encodable as? Encodable)?.encode(encoder) ?: throw EncodingError.invalidValue(encodable, EncodingError.Context(codingPath = this.codingPath, debugDescription = "Value of type ${encodable::class.qualifiedName} does not conform to Encodable and cannot be encoded"))
             try encodable.encode(to: encoder)
             return encoder.value
         }

--- a/Tests/SkipFoundationTests/Foundation/JSONTests.swift
+++ b/Tests/SkipFoundationTests/Foundation/JSONTests.swift
@@ -204,6 +204,22 @@ class TestJSON : XCTestCase {
         let thisIsADictionary: Dictionary<String, Bool>
     }
 
+    // skiptools/skip-foundation#62 repro fixtures
+    struct OptionalDictionaryFields : Equatable, Codable {
+        var optionalDict: [String: String]?
+        var nonOptionalDict: [String: String]
+    }
+
+    // Encode-only to isolate the #62 encode crash from an unrelated nested-dictionary *decode*
+    // codegen limitation (transpiled decoder types the inner dictionary as `Dictionary<*, *>`).
+    struct NestedDictionaryField : Encodable {
+        var nested: [String: [String: String]]
+    }
+
+    struct OptionalNestedDictionaryField : Encodable {
+        var nested: [String: [String: String]]?
+    }
+
     @inline(__always) private func enc<T: Encodable>(_ value: T, fmt: JSONEncoder.OutputFormatting? = .sortedKeys, data: JSONEncoder.DataEncodingStrategy? = nil, date: JSONEncoder.DateEncodingStrategy? = nil, floats: JSONEncoder.NonConformingFloatEncodingStrategy? = nil, keys: JSONEncoder.KeyEncodingStrategy? = nil) throws -> String {
         let encoder = JSONEncoder()
         if let fmt = fmt {
@@ -239,6 +255,23 @@ class TestJSON : XCTestCase {
         }
 
         return json
+    }
+
+    func testDictionaryCodableTypeErased() throws {
+        // skiptools/skip-foundation#62: encoding a populated Dictionary reached through a
+        // type-erased path — an optional dictionary via encodeIfPresent, or a Dictionary that
+        // is itself a value nested inside another Dictionary — crashed with
+        // "skip.lib.Tuple2 cannot be cast to skip.lib.Encodable". nil/empty succeeded, so it
+        // was easy to miss. A non-optional, statically-typed dictionary property already worked
+        // (see MyTestData) because the reified Dictionary overload is selected for it.
+        XCTAssertEqual(#"{"nonOptionalDict":{"a":"b"},"optionalDict":{"x":"y"}}"#,
+            try enc(OptionalDictionaryFields(optionalDict: ["x": "y"], nonOptionalDict: ["a": "b"])))
+        XCTAssertEqual(#"{"nonOptionalDict":{"a":"b"}}"#,
+            try enc(OptionalDictionaryFields(optionalDict: nil, nonOptionalDict: ["a": "b"])))
+        XCTAssertEqual(#"{"nested":{"outer":{"inner":"v"}}}"#,
+            try enc(NestedDictionaryField(nested: ["outer": ["inner": "v"]])))
+        XCTAssertEqual(#"{"nested":{"outer":{"inner":"v"}}}"#,
+            try enc(OptionalNestedDictionaryField(nested: ["outer": ["inner": "v"]])))
     }
 
     func testJSONCodable() throws {


### PR DESCRIPTION
Companion to the root fix in skiptools/skip-lib#46. This PR is the skip-foundation half of skiptools/skip-foundation#62.

## Motivation

Encoding a `Codable` type with a populated dictionary property can crash with:

```
skip.lib.ErrorException: java.lang.ClassCastException: skip.lib.Tuple2 cannot be cast to skip.lib.Encodable
    at skip.foundation._SpecialTreatmentEncoder.wrapEncodable(JSONEncoder.kt)
```

The root cause is in skip-lib's type-erased Codable dispatch (a `Dictionary` is also a `Sequence<Tuple2>`, so it was iterated as raw pairs) and is fixed in skiptools/skip-lib#46. This PR adds two things on the skip-foundation side.

## 1. Defense-in-depth in `wrapEncodable`

On SKIP the generic bound of `wrapEncodable<E: Encodable>` is weakened to `E: Any` (see the `// SKIP DECLARE` above it), so `(encodable as Encodable).encode(...)` is an unchecked downcast: any future value reaching this branch that is not `Encodable` fails with a bare `ClassCastException` naming nothing. Cast defensively and throw an `EncodingError` naming the concrete offending type instead — mirroring the `EncodingError.invalidValue` already thrown on the top-level encode path, and the "fail loud with an actionable message" pattern used elsewhere in the runtime. Behaviour is unchanged for genuine `Encodable` values.

## 2. Regression test

Adds a `JSONEncoder` round-trip/encode test (`testDictionaryCodableTypeErased`) covering an **optional** `[String: String]?` (the literal #62 shape, reached through `encodeIfPresent`) and **nested** `[String: [String: String]]` dictionaries — shapes not previously exercised (the suite only had non-optional dictionaries, which already worked). Against unpatched skip-lib this reproduces the `Tuple2 cannot be cast to Encodable` crash on Robolectric; with skip-lib#46 it passes and produces the correct JSON object shape.

The two nested fixtures are `Encodable`-only, to isolate the #62 *encode* crash from an unrelated nested-dictionary *decode* codegen limitation (the transpiled decoder types the inner dictionary as `Dictionary<*, *>`).

## Sequencing / CI note

The new test only passes once skip-lib#46 is released and this package's `skip-lib` dependency is bumped to include it. Until then it will fail against the currently pinned `skip-lib` 1.4.0 (reproducing the crash). The `wrapEncodable` hardening in part 1 is independent and safe to land on its own. Sequencing is yours to decide — happy to split the test out into a follow-up if you'd prefer to merge the hardening first.

## Testing

- `swift test` (native + transpiled/Robolectric), building against skip-lib#46 as a local dependency: the full `TestJSON` suite passes (5/5), including the new case; against unpatched skip-lib the new case reproduces the crash.

---

- [x] I have read and agree to the Contributor License Agreement.
- [x] `swift test` runs locally.
- [x] This change was prepared with AI assistance (Claude) and reviewed by me.
