### PR TITLE
Avoid kotlin-reflect when invoking AndroidBridge.initBridge at launch

### DIFF
--- a/Sources/SkipFoundation/ProcessInfo.swift
+++ b/Sources/SkipFoundation/ProcessInfo.swift
@@ -39,12 +39,14 @@ public class ProcessInfo {
                 if let packageMetaData = packageInfo.applicationInfo?.metaData {
                     if let bridgeModules = packageMetaData.getString("SKIP_BRIDGE_MODULES") {
                         android.util.Log.i("SkipFoundation", "loading SKIP_BRIDGE_MODULES: \(bridgeModules)")
-                        let bridgeClass = Class.forName("skip.android.bridge.AndroidBridge").kotlin
+                        // Use plain Java reflection rather than kotlin-reflect: initializing
+                        // kotlin.reflect.full here costs hundreds of ms of main-thread time at launch
+                        let bridgeClass = Class.forName("skip.android.bridge.AndroidBridge")
                         android.util.Log.i("SkipFoundation", "calling bridgeClass: \(bridgeClass)")
-                        if let companionObject = bridgeClass.companionObject,
-                            let initBridge = companionObject.functions?.find({ $0.name == "initBridge" }) {
+                        let companion = bridgeClass.getField("Companion").get(nil)
+                        if let initBridge = companion?.javaClass.getMethods().find({ $0.getName() == "initBridge" }) {
                             android.util.Log.i("SkipFoundation", "invoking initBridge: \(initBridge)")
-                            initBridge.call(bridgeClass.companionObjectInstance, bridgeModules)
+                            initBridge.invoke(companion, bridgeModules)
                         } else {
                             android.util.Log.w("SkipFoundation", "could not func skip.android.bridge.AndroidBridge.initBridge")
                         }


### PR DESCRIPTION
While profiling our app's cold start on Android we noticed that `ProcessInfo.launch(context:)` — which runs on the main thread in `Application.onCreate` — spends a surprising amount of time in the kotlin-reflect lookup used to invoke `AndroidBridge.initBridge`. Since it's typically the process's *first* use of kotlin-reflect, it pays the library's full one-time descriptor-machinery initialization: we measured ~176 ms on a Pixel 10 Pro Fold (debug build), and proportionally more on low-end devices, where it surfaces in Play/Sentry "Background ANR" reports during `ActivityThread.handleBindApplication`.

kotlin-reflect is clearly the right tool where Kotlin semantics matter (named/default arguments, nullability-aware overload matching — everything `skip.bridge.Reflector` does). This particular call site doesn't use any of those features, though: it invokes one known method with one `String` argument. So this PR switches it to plain `java.lang.reflect` — reading the `Companion` static field (a stable part of Kotlin's JVM ABI) and finding `initBridge` in `getMethods()` — which measures ~1 ms and keeps the existing logging and fallback warning intact.

Together with the companion PR skiptools/skip-android-bridge#33, this removes kotlin-reflect from the launch path entirely. Combined effect in our app: bridge init dropped from a median of 714 ms to 140 ms across 12 measured cold starts, verified end-to-end on device (app boots, bundle resources and localized strings load normally).

Happy to adjust the approach if you'd prefer a different shape — and thanks for Skip!

<details>
<summary>The production ANR stack that led us here (AppExitInfo, release build, low-end device, main thread during process bind)</summary>

This PR's target is in the bottom frames: `ProcessInfo.launch` invoking `initBridge` through kotlin-reflect (`DescriptorKCallable.call`) — the process's first kotlin-reflect touch. The hot frames above it (the `Reflector` scan of the `Context` hierarchy) are the companion PR's target.

```
at kotlin.reflect.jvm.internal.impl.descriptors.runtime.structure.ReflectJavaClassifierType.<init> (ReflectJavaClassifierType.kt:1)
at kotlin.reflect.jvm.internal.impl.descriptors.runtime.structure.ReflectJavaType$Factory.create (ReflectJavaType.java:33)
at kotlin.reflect.jvm.internal.impl.descriptors.runtime.structure.ReflectJavaArrayType.<init> (ReflectJavaArrayType.kt:28)
at kotlin.reflect.jvm.internal.impl.descriptors.runtime.structure.ReflectJavaType$Factory.create (ReflectJavaType.java:31)
at kotlin.reflect.jvm.internal.impl.descriptors.runtime.structure.ReflectJavaMember.getValueParameters (ReflectJavaMember.kt:55)
at kotlin.reflect.jvm.internal.impl.descriptors.runtime.structure.ReflectJavaMethod.getValueParameters (ReflectJavaMethod.kt:26)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.resolveMethodToFunctionDescriptor (LazyJavaScope.kt:166)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.declaredFunctions$lambda$0 (LazyJavaScope.kt:94)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.accessor$LazyJavaScope$lambda2 (LazyJavaScope.java:821)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope$$Lambda$2.invoke (LazyJavaScope.java:821)
at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunction.invoke (LockBasedStorageManager.java:578)
at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunctionToNotNull.invoke (LockBasedStorageManager.java:681)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.declaredFunctions$lambda$0 (LazyJavaScope.java:89)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.accessor$LazyJavaScope$lambda2 (LazyJavaScope.java:781)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope$$Lambda$2.invoke (LazyJavaScope.java:781)
at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunction.invoke (LockBasedStorageManager.java:578)
at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunctionToNotNull.invoke (LockBasedStorageManager.java:681)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.functions$lambda$0 (LazyJavaScope.java:119)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.accessor$LazyJavaScope$lambda4 (LazyJavaScope.java:87)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope$$Lambda$4.invoke (LazyJavaScope.java:87)
at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunction.invoke (LockBasedStorageManager.java:578)
at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunctionToNotNull.invoke (LockBasedStorageManager.java:681)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.getContributedFunctions (LazyJavaScope.kt:273)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaClassMemberScope.getContributedFunctions (LazyJavaClassMemberScope.kt:865)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaClassMemberScope.getFunctionsFromSupertypes (LazyJavaClassMemberScope.kt:490)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaClassMemberScope.computeNonDeclaredFunctions (LazyJavaClassMemberScope.kt:319)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.functions$lambda$0 (LazyJavaScope.java:123)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.accessor$LazyJavaScope$lambda4 (LazyJavaScope.java:183)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope$$Lambda$4.invoke (LazyJavaScope.java:183)
at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunction.invoke (LockBasedStorageManager.java:578)
at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunctionToNotNull.invoke (LockBasedStorageManager.java:681)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.getContributedFunctions (LazyJavaScope.kt:273)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaClassMemberScope.getContributedFunctions (LazyJavaClassMemberScope.kt:865)
at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedClassDescriptor$DeserializedClassMemberScope.computeNonDeclaredFunctions (DeserializedClassDescriptor.kt:311)
at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedMemberScope$OptimizedImplementation.computeFunctions (DeserializedMemberScope.java:277)
at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedMemberScope$OptimizedImplementation.functions$lambda$0 (DeserializedMemberScope.java:251)
at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedMemberScope$OptimizedImplementation.accessor$DeserializedMemberScope$OptimizedImplementation$lambda0 (DeserializedMemberScope.java:499)
at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedMemberScope$OptimizedImplementation$$Lambda$0.invoke (DeserializedMemberScope.java:499)
at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunction.invoke (LockBasedStorageManager.java:578)
at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunctionToNotNull.invoke (LockBasedStorageManager.java:681)
at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedMemberScope$OptimizedImplementation.getContributedFunctions (DeserializedMemberScope.java:329)
at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedMemberScope.getContributedFunctions (DeserializedMemberScope.kt:82)
at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedClassDescriptor$DeserializedClassMemberScope.getContributedFunctions (DeserializedClassDescriptor.kt:296)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaClassMemberScope.getFunctionsFromSupertypes (LazyJavaClassMemberScope.kt:490)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaClassMemberScope.computeNonDeclaredFunctions (LazyJavaClassMemberScope.kt:319)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.functions$lambda$0 (LazyJavaScope.java:123)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.accessor$LazyJavaScope$lambda4 (LazyJavaScope.java:183)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope$$Lambda$4.invoke (LazyJavaScope.java:183)
at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunction.invoke (LockBasedStorageManager.java:578)
at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunctionToNotNull.invoke (LockBasedStorageManager.java:681)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.getContributedFunctions (LazyJavaScope.kt:273)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaClassMemberScope.getContributedFunctions (LazyJavaClassMemberScope.kt:865)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.computeDescriptors (LazyJavaScope.java:378)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.allDescriptors$lambda$0 (LazyJavaScope.java:64)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.accessor$LazyJavaScope$lambda0 (LazyJavaScope.java:136)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope$$Lambda$0.invoke (LazyJavaScope.java:136)
at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$LockBasedLazyValue.invoke (LockBasedStorageManager.java:408)
at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$LockBasedNotNullLazyValue.invoke (LockBasedStorageManager.java:527)
at kotlin.reflect.jvm.internal.impl.load.java.lazy.descriptors.LazyJavaScope.getContributedDescriptors (LazyJavaScope.kt:357)
at kotlin.reflect.jvm.internal.impl.resolve.scopes.ResolutionScope$DefaultImpls.getContributedDescriptors$default (ResolutionScope.java:50)
at kotlin.reflect.jvm.internal.KClassImpl.getMembers (KClassImpl.kt:353)
at kotlin.reflect.jvm.internal.KClassImpl.access$getMembers (KClassImpl.kt:62)
at kotlin.reflect.jvm.internal.KClassImpl$Data.declaredNonStaticMembers_delegate$lambda$0 (KClassImpl.kt:302)
at kotlin.reflect.jvm.internal.KClassImpl$Data.accessor$KClassImpl$Data$lambda12 (KClassImpl.kt:1)
at kotlin.reflect.jvm.internal.KClassImpl$Data$$Lambda$12.invoke (KClassImpl.kt:3)
at kotlin.reflect.jvm.internal.ReflectProperties$LazySoftVal.invoke (ReflectProperties.java:70)
at kotlin.reflect.jvm.internal.ReflectProperties$Val.getValue (ReflectProperties.java:32)
at kotlin.reflect.jvm.internal.KClassImpl$Data.getDeclaredNonStaticMembers (KClassImpl.kt:302)
at kotlin.reflect.jvm.internal.KClassImpl$Data.allNonStaticMembers_delegate$lambda$0 (KClassImpl.kt:311)
at kotlin.reflect.jvm.internal.KClassImpl$Data.accessor$KClassImpl$Data$lambda16 (KClassImpl.kt:1)
at kotlin.reflect.jvm.internal.KClassImpl$Data$$Lambda$16.invoke (KClassImpl.kt:3)
at kotlin.reflect.jvm.internal.ReflectProperties$LazySoftVal.invoke (ReflectProperties.java:70)
at kotlin.reflect.jvm.internal.ReflectProperties$Val.getValue (ReflectProperties.java:32)
at kotlin.reflect.jvm.internal.KClassImpl$Data.getAllNonStaticMembers (KClassImpl.kt:311)
at kotlin.reflect.full.KClasses.getMemberFunctions (KClasses.kt:105)
at skip.bridge.Reflector.matchFunction (Reflector.kt:259)
at skip.bridge.Reflector.functionValue (Reflector.kt:232)
at skip.bridge.Reflector.objectFunction (Reflector.kt:163)
at skip.android.bridge.AndroidBridgeBootstrap$Companion.Swift_Companion_initAndroidBridge_0 (AndroidBridgeBootstrap.kt)
at skip.android.bridge.AndroidBridgeBootstrap$Companion.initAndroidBridge (AndroidBridgeBootstrap.kt:83)
at skip.android.bridge.AndroidBridge$Companion.initBridge (AndroidBridgeBootstrap.kt:42)
at java.lang.reflect.Method.invoke (Native method)
at kotlin.reflect.jvm.internal.calls.CallerImpl$Method.callMethod (CallerImpl.kt:97)
at kotlin.reflect.jvm.internal.calls.CallerImpl$Method$Instance.call (CallerImpl.kt:113)
at kotlin.reflect.jvm.internal.DescriptorKCallable.call (DescriptorKCallable.kt:141)
at skip.foundation.ProcessInfo$Companion.launch (ProcessInfo.kt:382)
at com.polymarket.android.PolymarketApplication.onCreate (PolymarketApplication.kt:37)
at android.app.Instrumentation.callApplicationOnCreate (Instrumentation.java:1316)
at android.app.ActivityThread.handleBindApplication (ActivityThread.java:7133)
```
</details>
