### PR TITLE
Add Locale preferred languages

### DIFF
--- a/Sources/SkipFoundation/Locale.swift
+++ b/Sources/SkipFoundation/Locale.swift
@@ -13,6 +13,19 @@ public struct Locale : Hashable, SwiftCustomBridged, KotlinConverting<java.util.
         return Array(java.util.Locale.getAvailableLocales().map({ $0.toString() }))
     }
 
+    /// The user's preferred languages, ordered from most to least preferred.
+    ///
+    /// Values use BCP-47 language tags, matching Foundation's API on Apple
+    /// platforms and Android's `LocaleList.toLanguageTags()` representation.
+    public static var preferredLanguages: [String] {
+        let localeList = android.os.LocaleList.getDefault()
+        var languages: [String] = []
+        for index in 0..<localeList.size() {
+            languages.append(localeList.get(index).toLanguageTag())
+        }
+        return languages
+    }
+
     public init(platformValue: java.util.Locale) {
         self.platformValue = platformValue
     }

--- a/Tests/SkipFoundationTests/Foundation/LocaleTests.swift
+++ b/Tests/SkipFoundationTests/Foundation/LocaleTests.swift
@@ -5,6 +5,19 @@ import XCTest
 
 @available(macOS 13, iOS 16, watchOS 10, tvOS 16, *)
 final class LocaleTests: XCTestCase {
+    func testPreferredLanguagesAreOrderedBCP47Tags() throws {
+        let languages = Locale.preferredLanguages
+        XCTAssertFalse(languages.isEmpty)
+        XCTAssertTrue(languages.allSatisfy { !$0.isEmpty })
+
+        #if SKIP
+        XCTAssertEqual(
+            languages.joined(separator: ","),
+            android.os.LocaleList.getDefault().toLanguageTags()
+        )
+        #endif
+    }
+
     func testLanguageCodes() throws {
         let fr = Locale(identifier: "fr_FR")
         XCTAssertNotNil(fr)


### PR DESCRIPTION
Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Codex generated the code under supervision

-----

## Summary

- Add [`Locale.preferredLanguages`](https://developer.apple.com/documentation/foundation/locale/preferredlanguages) to the Android SkipFoundation implementation, mirroring Apple Foundation's API.
- Return the device's ordered preferences as BCP-47 language tags from Android's `LocaleList`.
- Add coverage for ordering, non-empty values, and parity with `LocaleList.toLanguageTags()`.

## Usage Example

```swift
let languages = Locale.preferredLanguages
// For example: ["en-US", "fr-CA"]
```

## API Shape

```swift
extension Locale {
    public static var preferredLanguages: [String] { get }
}
```
